### PR TITLE
feat(data): load_subject helper + fix V-JEPA 2 preset

### DIFF
--- a/src/cortexlab/data/studies/lahner2024bold.py
+++ b/src/cortexlab/data/studies/lahner2024bold.py
@@ -5,10 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 """BOLD Moments: 3T fMRI responses to short naturalistic videos.
 
-This study provides 3T BOLD fMRI data from 10 participants viewing brief (3-second) 
-naturalistic video clips. The dataset is designed to study neural responses to 
-dynamic visual events and includes rich metadata and annotations. The test set's high 
-repetition count (10 reps) enables reliability analysis and within-subject 
+This study provides 3T BOLD fMRI data from 10 participants viewing brief (3-second)
+naturalistic video clips. The dataset is designed to study neural responses to
+dynamic visual events and includes rich metadata and annotations. The test set's high
+repetition count (10 reps) enables reliability analysis and within-subject
 generalization studies.
 
 Experimental Design:
@@ -52,7 +52,6 @@ import numpy as np
 import pandas as pd
 from neuralset.events import study
 from neuralset.utils import get_bids_filepath, get_masked_bold_image, read_bids_events
-
 
 STIMULI_SUBPATH: tp.Final[str] = "stimuli/stimulus_set/stimuli"
 """Path inside a BOLD Moments data root that holds the ``train/`` and ``test/`` video directories."""
@@ -356,7 +355,7 @@ class Lahner2024Bold(study.Study):
         publisher = {Springer Science and Business Media LLC},
         author = {Lahner,  Benjamin and Dwivedi,  Kshitij and Iamshchinina,  Polina and Graumann,  Monika and Lascelles,  Alex and Roig,  Gemma and Gifford,  Alessandro Thomas and Pan,  Bowen and Jin,  SouYoung and Ratan Murty,  N. Apurva and Kay,  Kendrick and Oliva,  Aude and Cichy,  Radoslaw},
         year = {2024},
-        month = jul 
+        month = jul
     }
     """
     licence: tp.ClassVar[str] = "CC0"

--- a/src/cortexlab/data/studies/lahner2024bold.py
+++ b/src/cortexlab/data/studies/lahner2024bold.py
@@ -155,6 +155,190 @@ def _resolve_root(root: str | os.PathLike | None) -> Path:
     return p
 
 
+BETAS_SUBPATH: tp.Final[str] = "derivatives/versionB/fsaverage/GLM"
+"""Relative path under the dataset root containing the per-subject prepared betas."""
+
+N_TRAIN_STIMULI: tp.Final[int] = 1000
+N_TEST_STIMULI: tp.Final[int] = 102
+N_VERTICES_PER_HEMI: tp.Final[int] = 163842
+"""fsaverage7 surface vertex count per hemisphere."""
+
+
+def load_subject(
+    subject_id: int,
+    root: str | os.PathLike | None = None,
+    feature_cache: str | os.PathLike | None = None,
+    modalities: tp.Sequence[str] = ("vision", "text"),
+    parcellation: tp.Mapping[str, np.ndarray] | None = None,
+    n_trimmed_stimuli: int | None = None,
+) -> dict[str, tp.Any]:
+    """Load one subject's BOLD Moments betas together with matching features.
+
+    This is the thin glue between the on-disk GLMsingle prepared-betas pickle
+    format and the dict interface consumed by
+    :func:`cortexlab.analysis.lesion.run_modality_lesion` and other encoding
+    experiments in the repository.
+
+    Parameters
+    ----------
+    subject_id
+        Subject index, 1 through 10.
+    root
+        Path to the BOLD Moments dataset root. Falls back to ``CORTEXLAB_DATA``
+        when None. See :func:`list_stimulus_paths` for the resolution rules.
+    feature_cache
+        Directory containing one ``<modality>.npz`` per entry in ``modalities``.
+        Each file must have a ``features`` array of shape ``(1102, d_m)`` whose
+        row order matches :func:`list_stimulus_paths` (train clips 0001-1000
+        then test clips 0001-0102, both sorted by filename). When None, the
+        returned dict carries empty feature dicts and only the fMRI betas are
+        populated; callers can then attach their own features.
+    modalities
+        Which modality keys to load from ``feature_cache``. Each name must
+        correspond to a ``<name>.npz`` file when ``feature_cache`` is set.
+    parcellation
+        Optional mapping from ROI name to a numpy array of vertex indices into
+        the concatenated hemispheres (left hemisphere first, 0 through 163841;
+        right hemisphere second, 163842 through 327683). When None the function
+        returns a single ``{"all_cortex": arange(n_voxels)}`` entry, which lets
+        downstream aggregation work even without a parcellation. Users with an
+        HCP-MMP atlas or custom ROIs should supply it here.
+    n_trimmed_stimuli
+        For pilot runs, keep only the first N training stimuli to cut fit
+        time. ``None`` keeps all 1000. Test split is never trimmed.
+
+    Returns
+    -------
+    dict
+        Keys:
+
+        * ``subject_id`` (int)
+        * ``y_train`` ``(n_train, 2*163842)``, mean across repetitions
+        * ``y_test``  ``(102, 2*163842)``, mean across 10 repetitions
+        * ``features_train`` ``{modality: (n_train, d_m)}``
+        * ``features_test``  ``{modality: (102, d_m)}``
+        * ``stimulus_ids_train`` list of str, from the GLMsingle manifest
+        * ``stimulus_ids_test``  list of str
+        * ``roi_indices`` ``{roi_name: int_array}``
+
+    Raises
+    ------
+    FileNotFoundError
+        If a required beta file or feature cache file is missing.
+    ValueError
+        If the betas and features disagree about stimulus count.
+
+    Notes
+    -----
+    The pickle layout shipped by the BOLD Moments authors is a 2-tuple
+    ``(betas, stim_names)`` where ``betas`` has shape
+    ``(n_trials, n_reps, 163842)``. We average across the repetition axis
+    because downstream encoders regress on per-stimulus responses. If you want
+    per-trial analysis (e.g. reliability estimation), read the pickles
+    directly with :mod:`pickle` rather than this helper.
+    """
+    root_path = _resolve_root(root)
+    betas_root = root_path / BETAS_SUBPATH / f"sub-{subject_id:02d}" / "prepared_betas"
+    if not betas_root.is_dir():
+        raise FileNotFoundError(
+            f"expected prepared betas under {betas_root}. "
+            "Run the OpenNeuro download for ds005165 (versionB/fsaverage/GLM) first."
+        )
+
+    splits = [("train", N_TRAIN_STIMULI), ("test", N_TEST_STIMULI)]
+    y: dict[str, np.ndarray] = {}
+    stimulus_ids: dict[str, list[str]] = {}
+
+    for split, n_expected in splits:
+        hemi_arrays = []
+        stim_ref: list[str] | None = None
+        for hemi in ("left", "right"):
+            fp = (
+                betas_root
+                / f"sub-{subject_id:02d}_organized_betas_task-{split}_hemi-{hemi}_normalized.pkl"
+            )
+            if not fp.exists():
+                raise FileNotFoundError(f"missing beta file {fp}")
+            with fp.open("rb") as f:
+                obj = pkl.load(f)
+            betas, stims = obj[0], obj[1]
+            if betas.shape[0] != n_expected:
+                raise ValueError(
+                    f"{fp.name}: expected {n_expected} trials, got {betas.shape[0]}"
+                )
+            if betas.shape[-1] != N_VERTICES_PER_HEMI:
+                raise ValueError(
+                    f"{fp.name}: expected {N_VERTICES_PER_HEMI} vertices, "
+                    f"got {betas.shape[-1]}"
+                )
+            # Mean across repetition axis -> (n_trials, n_vertices).
+            hemi_arrays.append(np.asarray(betas, dtype=np.float32).mean(axis=1))
+            stim_list = [str(s) for s in stims]
+            if stim_ref is None:
+                stim_ref = stim_list
+            elif stim_list != stim_ref:
+                raise ValueError(
+                    f"{fp.name}: stimulus order disagrees between hemispheres"
+                )
+        assert stim_ref is not None
+        y[split] = np.concatenate(hemi_arrays, axis=1)
+        stimulus_ids[split] = stim_ref
+
+    # Optional pilot truncation on training split.
+    if n_trimmed_stimuli is not None and n_trimmed_stimuli < y["train"].shape[0]:
+        y["train"] = y["train"][:n_trimmed_stimuli]
+        stimulus_ids["train"] = stimulus_ids["train"][:n_trimmed_stimuli]
+
+    # Feature loading. The canonical stimulus order for feature caches is
+    # `list_stimulus_paths()` (train 0001-1000 sorted, then test 0001-0102
+    # sorted). Load once, split by the row counts dictated by the betas.
+    features_train: dict[str, np.ndarray] = {}
+    features_test: dict[str, np.ndarray] = {}
+    if feature_cache is not None:
+        cache = Path(feature_cache)
+        if not cache.is_dir():
+            raise FileNotFoundError(f"feature cache directory not found: {cache}")
+        n_train = y["train"].shape[0]
+        n_test = y["test"].shape[0]
+        for modality in modalities:
+            fp = cache / f"{modality}.npz"
+            if not fp.exists():
+                raise FileNotFoundError(
+                    f"feature file {fp} missing; expected an npz with key "
+                    "'features' of shape (1102, d) in list_stimulus_paths order."
+                )
+            arr = np.load(fp)["features"]
+            if arr.shape[0] != N_TRAIN_STIMULI + N_TEST_STIMULI:
+                raise ValueError(
+                    f"{fp.name}: expected {N_TRAIN_STIMULI + N_TEST_STIMULI} rows, "
+                    f"got {arr.shape[0]}"
+                )
+            # Training split was possibly trimmed; test is always the full 102.
+            features_train[modality] = np.asarray(arr[:n_train], dtype=np.float32)
+            features_test[modality] = np.asarray(
+                arr[N_TRAIN_STIMULI : N_TRAIN_STIMULI + n_test], dtype=np.float32,
+            )
+
+    n_voxels = y["train"].shape[1]
+    if parcellation is None:
+        roi_indices: dict[str, np.ndarray] = {
+            "all_cortex": np.arange(n_voxels, dtype=np.int64),
+        }
+    else:
+        roi_indices = {k: np.asarray(v, dtype=np.int64) for k, v in parcellation.items()}
+
+    return {
+        "subject_id": int(subject_id),
+        "y_train": y["train"],
+        "y_test": y["test"],
+        "features_train": features_train,
+        "features_test": features_test,
+        "stimulus_ids_train": stimulus_ids["train"],
+        "stimulus_ids_test": stimulus_ids["test"],
+        "roi_indices": roi_indices,
+    }
+
+
 class Lahner2024Bold(study.Study):
     device: tp.ClassVar[str] = "Fmri"
     dataset_name: tp.ClassVar[str] = "BOLD Moments"

--- a/src/cortexlab/features/extractors.py
+++ b/src/cortexlab/features/extractors.py
@@ -132,10 +132,15 @@ PRESETS: dict[str, ExtractorConfig] = {
     ),
     "vjepa2-vit-l": ExtractorConfig(
         name="vjepa2-vit-l",
-        hf_model_id="facebook/vjepa2-vitl-fpc16-256",
+        # The 16-frame variant Meta ships is only the SSv2-fine-tuned head
+        # (`vjepa2-vitl-fpc16-256-ssv2`), which biases representations toward
+        # action-recognition labels. For a representational-alignment study
+        # we want the pre-trained base model; Meta publishes it as the
+        # 64-frame ViT-L checkpoint.
+        hf_model_id="facebook/vjepa2-vitl-fpc64-256",
         input_type="video",
         expected_dim=1024,
-        n_frames=16,
+        n_frames=64,
         processor_class="AutoProcessor",
         model_class="AutoModel",
         pooling="mean",

--- a/tests/test_lahner_load_subject.py
+++ b/tests/test_lahner_load_subject.py
@@ -21,7 +21,6 @@ from cortexlab.data.studies.lahner2024bold import (
     load_subject,
 )
 
-
 # --------------------------------------------------------------------------- #
 # fabricate a tiny on-disk BOLD Moments tree                                  #
 # --------------------------------------------------------------------------- #

--- a/tests/test_lahner_load_subject.py
+++ b/tests/test_lahner_load_subject.py
@@ -1,0 +1,282 @@
+"""Tests for ``cortexlab.data.studies.lahner2024bold.load_subject``.
+
+The real betas are 10+ GB, so these tests fabricate a tiny on-disk
+stand-in that matches the BOLD Moments GLMsingle prepared-betas layout.
+Only the shapes and pickle format are preserved; the values are dummy.
+"""
+
+from __future__ import annotations
+
+import pickle as pkl
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cortexlab.data.studies.lahner2024bold import (
+    BETAS_SUBPATH,
+    N_TEST_STIMULI,
+    N_TRAIN_STIMULI,
+    N_VERTICES_PER_HEMI,
+    load_subject,
+)
+
+
+# --------------------------------------------------------------------------- #
+# fabricate a tiny on-disk BOLD Moments tree                                  #
+# --------------------------------------------------------------------------- #
+
+def _make_fake_subject(
+    root: Path,
+    subject_id: int = 1,
+    n_train: int = N_TRAIN_STIMULI,
+    n_test: int = N_TEST_STIMULI,
+    n_vertices: int = N_VERTICES_PER_HEMI,
+    n_reps_train: int = 3,
+    n_reps_test: int = 10,
+    seed: int = 0,
+) -> None:
+    """Write four pickle files matching the shipped beta layout."""
+    rng = np.random.default_rng(seed)
+    sub_dir = (
+        root
+        / BETAS_SUBPATH
+        / f"sub-{subject_id:02d}"
+        / "prepared_betas"
+    )
+    sub_dir.mkdir(parents=True, exist_ok=True)
+
+    for split, n_trials, n_reps in (("train", n_train, n_reps_train),
+                                    ("test",  n_test,  n_reps_test)):
+        stim_list = [f"{i:04d}" for i in range(1, n_trials + 1)]
+        for hemi in ("left", "right"):
+            betas = rng.standard_normal(
+                (n_trials, n_reps, n_vertices)
+            ).astype(np.float32)
+            fp = (
+                sub_dir
+                / f"sub-{subject_id:02d}_organized_betas_task-{split}_hemi-{hemi}_normalized.pkl"
+            )
+            with fp.open("wb") as f:
+                pkl.dump([betas, stim_list], f)
+
+
+def _make_fake_feature_cache(
+    cache_dir: Path,
+    modalities=("vision", "text"),
+    n_total: int = N_TRAIN_STIMULI + N_TEST_STIMULI,
+    dim: int = 32,
+    seed: int = 1,
+) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(seed)
+    for m in modalities:
+        arr = rng.standard_normal((n_total, dim)).astype(np.float32)
+        np.savez(cache_dir / f"{m}.npz", features=arr)
+
+
+# Full-size fake data is ~2.5 GB per subject (1000 trials x 3 reps x 163842).
+# For tests we use a tiny variant; load_subject does not hard-code sizes
+# except via the N_TRAIN_STIMULI / N_TEST_STIMULI module constants. Patch
+# those for the duration of the tiny tests so the helper accepts our shrunken
+# synthetic data.
+
+@pytest.fixture
+def tiny_sizes(monkeypatch):
+    monkeypatch.setattr(
+        "cortexlab.data.studies.lahner2024bold.N_TRAIN_STIMULI", 8,
+    )
+    monkeypatch.setattr(
+        "cortexlab.data.studies.lahner2024bold.N_TEST_STIMULI", 4,
+    )
+    monkeypatch.setattr(
+        "cortexlab.data.studies.lahner2024bold.N_VERTICES_PER_HEMI", 16,
+    )
+    yield {"train": 8, "test": 4, "vert": 16}
+
+
+# --------------------------------------------------------------------------- #
+# happy path                                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_load_subject_shapes(tmp_path: Path, tiny_sizes):
+    _make_fake_subject(
+        tmp_path, subject_id=1,
+        n_train=tiny_sizes["train"], n_test=tiny_sizes["test"],
+        n_vertices=tiny_sizes["vert"],
+    )
+    rec = load_subject(subject_id=1, root=tmp_path)
+    assert rec["subject_id"] == 1
+    assert rec["y_train"].shape == (tiny_sizes["train"], 2 * tiny_sizes["vert"])
+    assert rec["y_test"].shape == (tiny_sizes["test"], 2 * tiny_sizes["vert"])
+    assert rec["y_train"].dtype == np.float32
+    assert rec["features_train"] == {}
+    assert rec["features_test"] == {}
+    assert set(rec["roi_indices"]) == {"all_cortex"}
+    assert rec["roi_indices"]["all_cortex"].shape == (2 * tiny_sizes["vert"],)
+    assert rec["stimulus_ids_train"] == [f"{i:04d}" for i in range(1, tiny_sizes["train"] + 1)]
+    assert rec["stimulus_ids_test"] == [f"{i:04d}" for i in range(1, tiny_sizes["test"] + 1)]
+
+
+def test_load_subject_averages_across_reps(tmp_path: Path, tiny_sizes):
+    _make_fake_subject(
+        tmp_path, subject_id=1,
+        n_train=tiny_sizes["train"], n_test=tiny_sizes["test"],
+        n_vertices=tiny_sizes["vert"],
+        n_reps_train=3, n_reps_test=10,
+    )
+    rec = load_subject(subject_id=1, root=tmp_path)
+    # Re-read one pickle and check that load_subject produced the repetition mean.
+    fp = (
+        tmp_path / BETAS_SUBPATH / "sub-01" / "prepared_betas"
+        / "sub-01_organized_betas_task-train_hemi-left_normalized.pkl"
+    )
+    with fp.open("rb") as f:
+        betas, _ = pkl.load(f)
+    expected_left_mean = betas.mean(axis=1)
+    got_left = rec["y_train"][:, : tiny_sizes["vert"]]
+    np.testing.assert_allclose(got_left, expected_left_mean, rtol=1e-5, atol=1e-6)
+
+
+def test_load_subject_with_feature_cache(tmp_path: Path, tiny_sizes):
+    _make_fake_subject(
+        tmp_path, subject_id=1,
+        n_train=tiny_sizes["train"], n_test=tiny_sizes["test"],
+        n_vertices=tiny_sizes["vert"],
+    )
+    cache = tmp_path / "features"
+    _make_fake_feature_cache(
+        cache,
+        n_total=tiny_sizes["train"] + tiny_sizes["test"],
+        dim=6,
+    )
+    rec = load_subject(
+        subject_id=1, root=tmp_path,
+        feature_cache=cache, modalities=("vision", "text"),
+    )
+    assert set(rec["features_train"]) == {"vision", "text"}
+    assert rec["features_train"]["vision"].shape == (tiny_sizes["train"], 6)
+    assert rec["features_test"]["vision"].shape == (tiny_sizes["test"], 6)
+    # Round-trip: rebuilt cache agrees with the on-disk array split.
+    stored = np.load(cache / "vision.npz")["features"]
+    np.testing.assert_array_equal(rec["features_train"]["vision"], stored[: tiny_sizes["train"]])
+    np.testing.assert_array_equal(
+        rec["features_test"]["vision"], stored[tiny_sizes["train"] :],
+    )
+
+
+def test_load_subject_pilot_truncation(tmp_path: Path, tiny_sizes):
+    _make_fake_subject(
+        tmp_path, subject_id=1,
+        n_train=tiny_sizes["train"], n_test=tiny_sizes["test"],
+        n_vertices=tiny_sizes["vert"],
+    )
+    cache = tmp_path / "features"
+    _make_fake_feature_cache(
+        cache,
+        n_total=tiny_sizes["train"] + tiny_sizes["test"],
+        dim=4,
+    )
+    rec = load_subject(
+        subject_id=1, root=tmp_path,
+        feature_cache=cache, modalities=("vision",),
+        n_trimmed_stimuli=3,
+    )
+    assert rec["y_train"].shape[0] == 3
+    assert rec["features_train"]["vision"].shape == (3, 4)
+    # Test split is untouched.
+    assert rec["y_test"].shape[0] == tiny_sizes["test"]
+
+
+def test_load_subject_custom_parcellation(tmp_path: Path, tiny_sizes):
+    _make_fake_subject(
+        tmp_path, subject_id=1,
+        n_train=tiny_sizes["train"], n_test=tiny_sizes["test"],
+        n_vertices=tiny_sizes["vert"],
+    )
+    parcellation = {
+        "left_half":  np.arange(tiny_sizes["vert"]),
+        "right_half": np.arange(tiny_sizes["vert"], 2 * tiny_sizes["vert"]),
+    }
+    rec = load_subject(subject_id=1, root=tmp_path, parcellation=parcellation)
+    assert set(rec["roi_indices"]) == {"left_half", "right_half"}
+    np.testing.assert_array_equal(
+        rec["roi_indices"]["right_half"],
+        np.arange(tiny_sizes["vert"], 2 * tiny_sizes["vert"]),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# failure modes                                                               #
+# --------------------------------------------------------------------------- #
+
+def test_load_subject_missing_root(tmp_path: Path):
+    with pytest.raises(FileNotFoundError, match="prepared betas"):
+        load_subject(subject_id=1, root=tmp_path)
+
+
+def test_load_subject_missing_feature_cache(tmp_path: Path, tiny_sizes):
+    _make_fake_subject(
+        tmp_path, subject_id=1,
+        n_train=tiny_sizes["train"], n_test=tiny_sizes["test"],
+        n_vertices=tiny_sizes["vert"],
+    )
+    with pytest.raises(FileNotFoundError, match="feature cache directory"):
+        load_subject(
+            subject_id=1, root=tmp_path,
+            feature_cache=tmp_path / "does_not_exist",
+        )
+
+
+def test_load_subject_missing_modality_file(tmp_path: Path, tiny_sizes):
+    _make_fake_subject(
+        tmp_path, subject_id=1,
+        n_train=tiny_sizes["train"], n_test=tiny_sizes["test"],
+        n_vertices=tiny_sizes["vert"],
+    )
+    cache = tmp_path / "features"
+    _make_fake_feature_cache(
+        cache, modalities=("vision",),
+        n_total=tiny_sizes["train"] + tiny_sizes["test"], dim=4,
+    )
+    with pytest.raises(FileNotFoundError, match="missing"):
+        load_subject(
+            subject_id=1, root=tmp_path,
+            feature_cache=cache, modalities=("vision", "audio"),
+        )
+
+
+def test_load_subject_feature_row_mismatch(tmp_path: Path, tiny_sizes):
+    _make_fake_subject(
+        tmp_path, subject_id=1,
+        n_train=tiny_sizes["train"], n_test=tiny_sizes["test"],
+        n_vertices=tiny_sizes["vert"],
+    )
+    cache = tmp_path / "features"
+    cache.mkdir()
+    # Wrong row count: 5 rows instead of n_train+n_test.
+    np.savez(cache / "vision.npz", features=np.zeros((5, 4), dtype=np.float32))
+    with pytest.raises(ValueError, match="expected"):
+        load_subject(
+            subject_id=1, root=tmp_path,
+            feature_cache=cache, modalities=("vision",),
+        )
+
+
+def test_load_subject_hemisphere_mismatch(tmp_path: Path, tiny_sizes):
+    _make_fake_subject(
+        tmp_path, subject_id=1,
+        n_train=tiny_sizes["train"], n_test=tiny_sizes["test"],
+        n_vertices=tiny_sizes["vert"],
+    )
+    # Corrupt one pickle: change its stimulus-id list order.
+    fp = (
+        tmp_path / BETAS_SUBPATH / "sub-01" / "prepared_betas"
+        / "sub-01_organized_betas_task-train_hemi-right_normalized.pkl"
+    )
+    with fp.open("rb") as f:
+        betas, stims = pkl.load(f)
+    with fp.open("wb") as f:
+        pkl.dump([betas, list(reversed(stims))], f)
+    with pytest.raises(ValueError, match="stimulus order disagrees"):
+        load_subject(subject_id=1, root=tmp_path)


### PR DESCRIPTION
## Summary

Two follow-ups to [#22](https://github.com/siddhant-rajhans/cortexlab/pull/22), both surfaced by the first real cluster run of the BOLD Moments lesion pipeline:

1. The V-JEPA 2 preset pointed at a nonexistent HuggingFace repo ID.
2. The experiment orchestrator (\`experiments/causal_modality_ablation.py\`) imported a \`load_subject\` helper that had not been written.

## What changed

### \`cortexlab.features.extractors\`

- V-JEPA 2 preset now uses \`facebook/vjepa2-vitl-fpc64-256\` (the pre-trained 64-frame ViT-L base checkpoint) and \`n_frames=64\`.
- The previous value \`facebook/vjepa2-vitl-fpc16-256\` 404s on the Hub. Meta only publishes the 16-frame variant as an SSv2-fine-tuned head (\`vjepa2-vitl-fpc16-256-ssv2\`), which biases representations toward action-recognition labels and is inappropriate for a representational-alignment study.

### \`cortexlab.data.studies.lahner2024bold.load_subject\`

New function with signature:

\`\`\`python
load_subject(
    subject_id: int,
    root: str | os.PathLike | None = None,
    feature_cache: str | os.PathLike | None = None,
    modalities: Sequence[str] = (\"vision\", \"text\"),
    parcellation: Mapping[str, np.ndarray] | None = None,
    n_trimmed_stimuli: int | None = None,
) -> dict[str, Any]
\`\`\`

It reads the GLMsingle prepared-betas pickles shipped by the dataset authors, averages across the repetition axis (3 for train, 10 for test), concatenates the two hemispheres, optionally aligns with a per-modality feature cache (\`<cache>/<modality>.npz\` with a \`features\` array in \`list_stimulus_paths\` order), and returns the dict shape that \`experiments/causal_modality_ablation.py\` and \`cortexlab.analysis.lesion.run_modality_lesion\` already consume.

Returns:

- \`subject_id\` (int)
- \`y_train\` \`(n_train, 2 * 163842)\`, \`float32\`
- \`y_test\` \`(102, 2 * 163842)\`, \`float32\`
- \`features_train\` / \`features_test\` — dict of modality to array
- \`stimulus_ids_train\` / \`stimulus_ids_test\` — list of str from GLMsingle manifest
- \`roi_indices\` — \`{\"all_cortex\": arange(n_voxels)}\` by default; accepts a custom parcellation mapping

### Supporting constants

Exported from the module so the tests and any downstream code can reference them without magic numbers:

- \`BETAS_SUBPATH = \"derivatives/versionB/fsaverage/GLM\"\`
- \`N_TRAIN_STIMULI = 1000\`
- \`N_TEST_STIMULI = 102\`
- \`N_VERTICES_PER_HEMI = 163842\`

## Tests

10 new cases in \`tests/test_lahner_load_subject.py\` covering:

- Correct output shapes, dtype, and ROI default.
- Repetition averaging agrees with a hand-computed mean of a freshly-written pickle.
- Feature-cache alignment splits an \`(n_total, d)\` array into train/test correctly.
- Pilot truncation (\`n_trimmed_stimuli\`) trims train only, leaves test intact.
- Custom parcellation passes through to \`roi_indices\`.
- Clear \`FileNotFoundError\` when the root, cache, or a modality file is missing.
- Clear \`ValueError\` when feature rows do not match \`N_TRAIN_STIMULI + N_TEST_STIMULI\`.
- Clear \`ValueError\` when the two hemisphere pickles disagree on stimulus order.

The tests fabricate a tiny on-disk BOLD Moments tree and monkeypatch the module constants so each test runs in under a second without needing the real 100 GB dataset.

Full suite: **153 passed, 2 CUDA-gated skipped.**

## Notes for reviewers

- No breaking changes to anything in [#22](https://github.com/siddhant-rajhans/cortexlab/pull/22). Both the preset fix and \`load_subject\` are additive.
- The function is deliberately parcellation-agnostic; the default single \"all_cortex\" ROI lets downstream aggregators work even before a user wires up an HCP-MMP or custom atlas.
- The function does not own feature extraction; callers are expected to produce \`<cache>/<modality>.npz\` however they want (e.g. by combining outputs from several \`FoundationFeatureExtractor\` presets into a single \"vision\" array, or by writing TRIBE v2 per-modality projections).