### PR TITLE
fix(experiments): thread --data-root / --feature-cache / --modalities through orchestrator

### DIFF
--- a/experiments/causal_modality_ablation.py
+++ b/experiments/causal_modality_ablation.py
@@ -80,6 +80,14 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--backend", type=str, default="auto")
     ap.add_argument("--mock", action="store_true",
                     help="Run on synthetic data for smoke-testing.")
+    ap.add_argument("--data-root", type=str, default=None,
+                    help="BOLD Moments dataset root. Overrides yaml/env.")
+    ap.add_argument("--feature-cache", type=str, default=None,
+                    help="Directory containing <modality>.npz files "
+                         "produced by experiments.build_feature_cache.")
+    ap.add_argument("--modalities", type=str, default="vision,text",
+                    help="Comma-separated modality names whose .npz files "
+                         "live in --feature-cache.")
     return ap.parse_args()
 
 
@@ -99,20 +107,24 @@ def _load_subject_data(
 ) -> dict:
     """Load features and responses for one subject.
 
-    The heavy lifting (BOLD Moments loader + TRIBE v2 feature extraction)
-    lives in ``cortexlab.data.studies.lahner2024bold``; this wrapper
-    exists so we can return a uniform dict regardless of whether data
-    came from disk or from the mock generator.
+    The heavy lifting (BOLD Moments loader) lives in
+    :mod:`cortexlab.data.studies.lahner2024bold`; this wrapper exists so
+    the orchestrator can return a uniform dict regardless of whether the
+    data came from disk or from the mock generator.
+
+    ``cfg`` is the merged configuration (YAML plus CLI overrides), so the
+    helper does not need to know which source set each field.
     """
     from cortexlab.data.studies.lahner2024bold import load_subject  # lazy
 
+    modalities = cfg.get("modalities") or ["vision", "text"]
     rec = load_subject(
         subject_id=subject_id,
         root=cfg.get("data_root"),
         feature_cache=cfg.get("feature_cache"),
+        modalities=tuple(modalities),
+        n_trimmed_stimuli=pilot,
     )
-    if pilot is not None:
-        rec = _subset(rec, pilot)
     return rec
 
 
@@ -282,6 +294,17 @@ def main() -> None:
                         format="%(asctime)s %(levelname)s %(name)s: %(message)s")
     args = _parse_args()
     cfg = _load_config(args.config)
+
+    # CLI overrides YAML. Only apply when the user actually passed
+    # something different from the defaults (`None` or the sentinel
+    # "vision,text" for modalities).
+    if args.data_root is not None:
+        cfg["data_root"] = args.data_root
+    if args.feature_cache is not None:
+        cfg["feature_cache"] = args.feature_cache
+    if args.modalities:
+        cfg["modalities"] = [m.strip() for m in args.modalities.split(",") if m.strip()]
+
     alphas = [float(a) for a in args.alphas.split(",")]
 
     run_study(


### PR DESCRIPTION
## Summary

The lesion orchestrator had CLI args for compute config (device, backend, alphas, cv, mask) but not for data paths. On Jarvis the lesion pilot would crash because \`load_subject\` got \`feature_cache=None\` (no YAML), returned empty feature dicts, and \`run_modality_lesion\` raised \"needs at least 2 modalities\".

## What changed

\`experiments/causal_modality_ablation.py\` gets three CLI flags:

| Flag | Purpose |
|---|---|
| \`--data-root PATH\` | override \`cfg.data_root\` (and \`CORTEXLAB_DATA\`) |
| \`--feature-cache PATH\` | directory of \`<modality>.npz\` written by \`build_feature_cache\` |
| \`--modalities LIST\` | comma-separated modality keys; default \`\"vision,text\"\` to match the cache builder shipped in #40 |

CLI beats YAML when both set the same key.

Also drops the ad-hoc \`_subset\` post-load truncation path in favor of \`load_subject\`'s \`n_trimmed_stimuli\` kwarg so pilot trimming happens at load time instead of after we already paid for the full pickle read.

## Test

Smoke:

\`\`\`
python -m experiments.causal_modality_ablation --mock --subjects 1 \
  --modalities vision,text --output /tmp/smoke
\`\`\`

runs clean and writes a manifest. Full suite: **176 passed, 3 CUDA-gated skipped**.

## Typical real invocation after this PR

\`\`\`
python -m experiments.causal_modality_ablation \
  --subjects 1 2 3 \
  --data-root \$CORTEXLAB_DATA/bold_moments \
  --feature-cache \$CORTEXLAB_RESULTS/features \
  --modalities vision,text \
  --device cuda --backend torch \
  --alphas 0.01,1,100,10000,1000000 --cv 5 --mask zero \
  --output \$CORTEXLAB_RESULTS/lesion/\$(date +%Y%m%d_%H%M%S)
\`\`\`