### PR TITLE
fix(data): middle_frame_paths handles CSAIL naming convention

### DIFF
--- a/src/cortexlab/data/studies/lahner2024bold.py
+++ b/src/cortexlab/data/studies/lahner2024bold.py
@@ -42,6 +42,7 @@ Download Requirements:
 """
 
 import json
+import logging
 import os
 import pickle as pkl
 import typing as tp
@@ -52,6 +53,8 @@ import numpy as np
 import pandas as pd
 from neuralset.events import study
 from neuralset.utils import get_bids_filepath, get_masked_bold_image, read_bids_events
+
+logger = logging.getLogger(__name__)
 
 STIMULI_SUBPATH: tp.Final[str] = "stimuli/stimulus_set/stimuli"
 """Path inside a BOLD Moments data root that holds the ``train/`` and ``test/`` video directories."""
@@ -257,9 +260,12 @@ def middle_frame_paths(
 
     Image models (CLIP, DINOv2, SigLIP, PaliGemma) use the middle frame of
     each clip for alignment benchmarks. The CSAIL stimulus archive places
-    these at ``stimulus_set/frames_middle/<stem>.jpg``. Order matches
-    ``list_stimulus_paths`` so a row-wise concatenation with vision or text
-    features stays stable.
+    these at ``stimulus_set/frames_middle/`` but with a naming convention
+    that carries the extracted frame index in the filename, e.g.
+    ``0001_45_90.jpg`` for stimulus 0001 (frame 45 of 90). This helper
+    tries the bare ``<stem>.jpg`` first and then falls back to the
+    ``<stem>_*.jpg`` glob, so both a vanilla CSAIL extraction and a
+    simplified symlink tree work. Order matches ``list_stimulus_paths``.
     """
     root_path = _resolve_root(root)
     frames_root = root_path / "stimulus_set" / "frames_middle"
@@ -270,10 +276,26 @@ def middle_frame_paths(
         )
     paths = []
     for video_path in list_stimulus_paths(root):
-        frame_path = frames_root / f"{video_path.stem}{suffix}"
-        if not frame_path.exists():
-            raise FileNotFoundError(f"missing middle frame for {video_path.stem}: {frame_path}")
-        paths.append(frame_path)
+        stem = video_path.stem
+        bare = frames_root / f"{stem}{suffix}"
+        if bare.exists():
+            paths.append(bare)
+            continue
+        matches = sorted(frames_root.glob(f"{stem}_*{suffix}"))
+        if not matches:
+            raise FileNotFoundError(
+                f"missing middle frame for {stem} under {frames_root}. "
+                f"Tried {bare.name} and {stem}_*{suffix}."
+            )
+        # BOLD Moments ships exactly one middle-frame file per stimulus.
+        # If more than one matches, take the first in sorted order and
+        # continue; a warning keeps the surprise visible without aborting.
+        if len(matches) > 1:
+            logger.warning(
+                "multiple middle-frame candidates for %s: %s. Using %s.",
+                stem, [m.name for m in matches], matches[0].name,
+            )
+        paths.append(matches[0])
     return paths
 
 

--- a/tests/test_lahner_captions_and_frames.py
+++ b/tests/test_lahner_captions_and_frames.py
@@ -152,3 +152,56 @@ def test_middle_frame_paths_missing_one_frame(tmp_path: Path):
     _make_middle_frames(tmp_path, stems[:-1])  # skip the last stem
     with pytest.raises(FileNotFoundError, match="missing middle frame"):
         middle_frame_paths(tmp_path)
+
+
+def test_middle_frame_paths_resolves_csail_suffix(tmp_path: Path):
+    """CSAIL ships frames named ``<stem>_<frame_idx>_<total>.jpg`` rather
+    than the bare ``<stem>.jpg`` the docstring implies. The helper should
+    glob for the CSAIL convention when the bare filename is absent.
+    """
+    _make_stimuli_tree(tmp_path, n_train=3, n_test=2)
+    frames_root = tmp_path / "stimulus_set" / "frames_middle"
+    frames_root.mkdir(parents=True, exist_ok=True)
+    for i in range(1, 6):
+        (frames_root / f"{i:04d}_45_90.jpg").write_bytes(b"\xff\xd8\xff\xd9")
+    frames = middle_frame_paths(tmp_path)
+    assert len(frames) == 5
+    assert [f.name for f in frames] == [f"{i:04d}_45_90.jpg" for i in range(1, 6)]
+
+
+def test_middle_frame_paths_prefers_bare_over_glob(tmp_path: Path):
+    """When both a symlink named ``<stem>.jpg`` and the CSAIL-style
+    ``<stem>_<idx>.jpg`` exist, the bare file wins so user-built symlink
+    trees are respected and no warning fires.
+    """
+    # Use 1 train + 1 test to satisfy list_stimulus_paths' requirement
+    # that both split directories are populated.
+    _make_stimuli_tree(tmp_path, n_train=1, n_test=1)
+    frames_root = tmp_path / "stimulus_set" / "frames_middle"
+    frames_root.mkdir(parents=True, exist_ok=True)
+    (frames_root / "0001_45_90.jpg").write_bytes(b"\xff\xd8\xff\xd9")
+    (frames_root / "0001.jpg").write_bytes(b"\xff\xd8\xff\xd9")
+    (frames_root / "0002_45_90.jpg").write_bytes(b"\xff\xd8\xff\xd9")
+    frames = middle_frame_paths(tmp_path)
+    assert len(frames) == 2
+    # Stem 0001 has a bare form; the helper must prefer it over the glob.
+    assert frames[0].name == "0001.jpg"
+    assert frames[1].name == "0002_45_90.jpg"
+
+
+def test_middle_frame_paths_warns_on_ambiguous_glob(tmp_path: Path, caplog):
+    """Two CSAIL-style files for the same stem is a data bug; pick the
+    first sorted match and warn so the surprise is visible.
+    """
+    import logging as stdlib_logging
+    _make_stimuli_tree(tmp_path, n_train=1, n_test=1)
+    frames_root = tmp_path / "stimulus_set" / "frames_middle"
+    frames_root.mkdir(parents=True, exist_ok=True)
+    (frames_root / "0001_30_60.jpg").write_bytes(b"\xff\xd8\xff\xd9")
+    (frames_root / "0001_45_90.jpg").write_bytes(b"\xff\xd8\xff\xd9")
+    (frames_root / "0002_45_90.jpg").write_bytes(b"\xff\xd8\xff\xd9")
+    with caplog.at_level(stdlib_logging.WARNING,
+                         logger="cortexlab.data.studies.lahner2024bold"):
+        frames = middle_frame_paths(tmp_path)
+    assert frames[0].name == "0001_30_60.jpg"   # sorted pick for stem 0001
+    assert any("multiple middle-frame" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Surfaced on Jarvis during the first real feature-extraction run (job 1032215). The CSAIL \`stimulus_set.zip\` ships middle frames as \`<stem>_<frame_idx>_<total>.jpg\` (e.g. \`0001_45_90.jpg\` = frame 45 of 90 for stimulus 0001). \`middle_frame_paths\` was hard-coded to look for the bare \`<stem>.jpg\` and crashed on the first stimulus with:

\`\`\`
FileNotFoundError: missing middle frame for 0001:
  .../stimulus_set/frames_middle/0001.jpg
\`\`\`

## What changed

Resolution order in \`middle_frame_paths\`:

1. Try bare \`<stem>.jpg\` first so user-built symlink trees keep working.
2. Fall back to glob \`<stem>_*.jpg\` and pick \`sorted[0]\`.
3. Warn if more than one glob match exists (should not happen in a clean CSAIL extraction).
4. Raise \`FileNotFoundError\` with a clear message only when neither matches.

Also adds a module-level logger so the warning path works.

## Tests

Three new cases plus existing ones:

| Case | Passes now |
|---|---|
| Fresh CSAIL extraction (suffixed filenames) | yes |
| User-built symlink tree (bare filenames) | yes |
| Mixed: both bare and suffixed present | picks the bare |
| Ambiguous glob (two suffixed files for same stem) | warns, picks sorted first |
| Missing frame entirely | raises with a useful message |

Full suite: **179 passed, 3 CUDA-gated skipped**.

## Alternative considered

Generating 1102 symlinks on disk works (and is what unblocked Jarvis tonight), but it does not scale: every new user of cortexlab hits the same wall. This fix keeps the dataset directory untouched and puts the resolution logic in the helper where it belongs.