### PR TITLE
fix(features): unwrap transformers 5.x CLIPModel.get_text_features return

### DIFF
--- a/src/cortexlab/features/text.py
+++ b/src/cortexlab/features/text.py
@@ -70,6 +70,34 @@ class TextExtractorConfig:
     pooling: str = "projection"
 
 
+def _as_tensor(x) -> torch.Tensor:
+    """Normalize whatever ``CLIPModel.get_text_features`` returns in the
+    running ``transformers`` version into a plain tensor.
+
+    transformers 4.x returned the projected embedding directly as a
+    tensor. transformers 5.x wrapped it in a ``BaseModelOutputWithPooling``
+    (and variants), losing the tensor API on the return value. This
+    helper handles both cases and a couple of common adjacent attribute
+    names so the feature extractor is robust across versions.
+    """
+    if isinstance(x, torch.Tensor):
+        return x
+    # Common attribute names on text-model output objects, in preference order.
+    for attr in ("text_embeds", "pooler_output", "logits"):
+        val = getattr(x, attr, None)
+        if isinstance(val, torch.Tensor):
+            return val
+    last = getattr(x, "last_hidden_state", None)
+    if isinstance(last, torch.Tensor):
+        # CLS pooling as a last resort; callers that care about projection
+        # have already tried every more specific path above.
+        return last[:, 0]
+    raise TypeError(
+        f"get_text_features returned {type(x).__name__!s}; "
+        "cannot extract a tensor from it."
+    )
+
+
 TEXT_PRESETS: dict[str, TextExtractorConfig] = {
     "clip-text-vit-l-14": TextExtractorConfig(
         name="clip-text-vit-l-14",
@@ -208,7 +236,8 @@ class TextFeatureExtractor:
             # CLIP / SigLIP expose a projected text embedding.
             getter = getattr(self._model, "get_text_features", None)
             if getter is not None:
-                return getter(**inputs)
+                result = getter(**inputs)
+                return _as_tensor(result)
             # Fall through to CLS.
             pooling = "cls"
         outputs = self._model(**inputs)

--- a/tests/test_text_features.py
+++ b/tests/test_text_features.py
@@ -227,6 +227,42 @@ def test_save_and_load_cache(tmp_path: Path, texts):
     np.testing.assert_array_equal(feats, restored)
 
 
+class _FakeOutputWithTextEmbeds:
+    """Mimics transformers 5.x CLIPModel.get_text_features return type."""
+
+    def __init__(self, text_embeds):
+        self.text_embeds = text_embeds
+
+
+class _FakeModelReturningOutputObject(torch.nn.Module):
+    """CLIP-style model whose get_text_features returns an output object
+    (transformers 5.x behavior) rather than a plain tensor.
+    """
+
+    def __init__(self, dim=768, vocab_size=256):
+        super().__init__()
+        self.embed = torch.nn.Embedding(vocab_size, dim)
+        self.proj = torch.nn.Linear(dim, dim)
+
+    def get_text_features(self, input_ids, attention_mask=None):
+        emb = self.embed(input_ids).mean(1)
+        return _FakeOutputWithTextEmbeds(text_embeds=self.proj(emb))
+
+
+def test_projection_path_handles_transformers_v5_output_object(texts):
+    """Regression for transformers 5.x where get_text_features returns
+    a BaseModelOutputWithPooling-style object instead of a tensor.
+    Without the _as_tensor unwrap the extractor would crash on .detach.
+    """
+    ext = TextFeatureExtractor.from_preset(
+        "clip-text-vit-l-14", device="cpu",
+        model_factory=_factory(_FakeModelReturningOutputObject(dim=768)),
+    )
+    feats = ext.extract(texts)
+    assert feats.shape == (3, 768)
+    assert feats.dtype == np.float32
+
+
 def test_cache_key_is_deterministic_and_sensitive():
     ext = TextFeatureExtractor.from_preset(
         "clip-text-vit-l-14", device="cpu",


### PR DESCRIPTION
## Summary

Surfaced on Jarvis during the first real feature-extraction run (job 1032215). Vision extraction ran cleanly over all 1102 DINOv2 middle frames. The text half then crashed:

\`\`\`
File \".../features/text.py\", line 196, in _forward_batch
    return feats.detach().to(torch.float32).cpu().numpy()
AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'detach'
\`\`\`

Root cause: transformers 4.x returned \`CLIPModel.get_text_features\` as a plain tensor. transformers 5.x (the version pinned in the Jarvis env) wraps it in a \`BaseModelOutputWithPooling\`-style object, so \`.detach\` is no longer defined on the return value.

## Fix

Adds an \`_as_tensor\` helper that normalizes either return shape:

| Observed type | Returned |
|---|---|
| \`torch.Tensor\` (transformers 4.x) | as-is |
| Object with \`text_embeds\` (transformers 5.x CLIP) | \`.text_embeds\` |
| Object with \`pooler_output\` | \`.pooler_output\` |
| Object with \`logits\` | \`.logits\` |
| Object with \`last_hidden_state\` | CLS of \`.last_hidden_state\` |
| anything else | \`TypeError\` with the observed type |

Wraps the one call site in \`_pool\` that invokes \`get_text_features\`.

## Test

\`test_projection_path_handles_transformers_v5_output_object\` uses a stub CLIP-shaped model whose \`get_text_features\` returns a \`_FakeOutputWithTextEmbeds\` object (mimicking transformers 5.x). The extractor must produce the right-shape tensor without crashing.

Full suite: **177 passed, 3 CUDA-gated skipped**.

## Impact

Unblocks \`experiments/build_feature_cache.py\` on any environment running transformers 5.x. No behavior change on transformers 4.x because the first branch of \`_as_tensor\` is an identity passthrough for tensors.