### PR TITLE
feat(data): HCP-MMP fsaverage parcellation loader + --parcellation flag

### DIFF
--- a/experiments/causal_modality_ablation.py
+++ b/experiments/causal_modality_ablation.py
@@ -88,6 +88,19 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--modalities", type=str, default="vision,text",
                     help="Comma-separated modality names whose .npz files "
                          "live in --feature-cache.")
+    ap.add_argument("--parcellation", type=str, default="none",
+                    choices=["none", "hcp-mmp"],
+                    help="Parcellation to report ROI-level results against. "
+                         "'none' keeps a single 'all_cortex' bucket. "
+                         "'hcp-mmp' requires --lh-annot and --rh-annot.")
+    ap.add_argument("--lh-annot", type=str, default=None,
+                    help="Left-hemisphere FreeSurfer .annot file for the "
+                         "HCP-MMP (or compatible) parcellation.")
+    ap.add_argument("--rh-annot", type=str, default=None,
+                    help="Right-hemisphere FreeSurfer .annot file.")
+    ap.add_argument("--parcellation-rois", type=str, default=None,
+                    help="Comma-separated ROI names to include. None uses the "
+                         "DEFAULT_HCP_MMP_ROIS set from cortexlab.data.parcellations.")
     return ap.parse_args()
 
 
@@ -102,8 +115,33 @@ def _load_config(path: str | None) -> dict:
 # data loading                                                                #
 # --------------------------------------------------------------------------- #
 
+def _resolve_parcellation(cfg: dict) -> dict[str, np.ndarray] | None:
+    """Build the ``{roi_name: indices}`` dict from CLI/yaml config, or None.
+
+    Separated from ``_load_subject_data`` so the parcellation is loaded
+    exactly once and shared across subjects (the annot files are identical
+    for every subject on fsaverage).
+    """
+    kind = cfg.get("parcellation") or "none"
+    if kind == "none":
+        return None
+    if kind == "hcp-mmp":
+        from cortexlab.data.parcellations import load_hcp_mmp_fsaverage  # lazy
+        lh = cfg.get("lh_annot")
+        rh = cfg.get("rh_annot")
+        if not lh or not rh:
+            raise ValueError(
+                "parcellation=hcp-mmp requires --lh-annot and --rh-annot "
+                "(or the equivalent yaml keys lh_annot / rh_annot)."
+            )
+        rois = cfg.get("parcellation_rois")
+        return load_hcp_mmp_fsaverage(lh, rh, rois=rois)
+    raise ValueError(f"unknown parcellation {kind!r}")
+
+
 def _load_subject_data(
     subject_id: int, cfg: dict, pilot: int | None,
+    parcellation: dict[str, np.ndarray] | None = None,
 ) -> dict:
     """Load features and responses for one subject.
 
@@ -113,7 +151,9 @@ def _load_subject_data(
     data came from disk or from the mock generator.
 
     ``cfg`` is the merged configuration (YAML plus CLI overrides), so the
-    helper does not need to know which source set each field.
+    helper does not need to know which source set each field. ``parcellation``
+    is threaded through to ``load_subject`` so per-ROI aggregation is done
+    downstream in the orchestrator.
     """
     from cortexlab.data.studies.lahner2024bold import load_subject  # lazy
 
@@ -123,6 +163,7 @@ def _load_subject_data(
         root=cfg.get("data_root"),
         feature_cache=cfg.get("feature_cache"),
         modalities=tuple(modalities),
+        parcellation=parcellation,
         n_trimmed_stimuli=pilot,
     )
     return rec
@@ -230,9 +271,19 @@ def run_study(
     lesion_objs: dict[int, LesionResult] = {}
     responses_for_ceiling = []
 
+    # Parcellation is shared across subjects; load once. Mock mode keeps
+    # its synthetic per-modality ROI bucket regardless.
+    parcellation = None if mock else _resolve_parcellation(cfg)
+    if parcellation is not None:
+        logger.info("parcellation loaded: %d ROIs", len(parcellation))
+
     for sid in subject_ids:
         logger.info("loading subject %d", sid)
-        rec = _mock_subject_data(sid) if mock else _load_subject_data(sid, cfg, pilot)
+        rec = (
+            _mock_subject_data(sid)
+            if mock
+            else _load_subject_data(sid, cfg, pilot, parcellation=parcellation)
+        )
         summary, lesion = run_one_subject(
             rec, alphas=alphas, cv=cv, mask=mask,
             device=device, backend=backend,
@@ -304,6 +355,16 @@ def main() -> None:
         cfg["feature_cache"] = args.feature_cache
     if args.modalities:
         cfg["modalities"] = [m.strip() for m in args.modalities.split(",") if m.strip()]
+    if args.parcellation:
+        cfg["parcellation"] = args.parcellation
+    if args.lh_annot is not None:
+        cfg["lh_annot"] = args.lh_annot
+    if args.rh_annot is not None:
+        cfg["rh_annot"] = args.rh_annot
+    if args.parcellation_rois:
+        cfg["parcellation_rois"] = [
+            r.strip() for r in args.parcellation_rois.split(",") if r.strip()
+        ]
 
     alphas = [float(a) for a in args.alphas.split(",")]
 

--- a/src/cortexlab/data/parcellations.py
+++ b/src/cortexlab/data/parcellations.py
@@ -1,0 +1,359 @@
+"""Cortical parcellation loaders for brain-encoding experiments.
+
+A *parcellation* maps each cortical vertex to a named region of interest
+(ROI). Brain-encoding studies typically report per-ROI statistics (mean
+R^2, delta R^2 under lesion, alignment strength) rather than per-vertex
+numbers, because the per-vertex signal is noisy and the neuroscience
+narrative lives at the ROI level (V1, FFA, STG, ATL, etc.).
+
+This module exposes two things:
+
+1. :func:`build_roi_indices` — a pure-data helper that converts the
+   FreeSurfer ``.annot`` format (``labels``, ``names``) into the
+   ``{roi_name: int_array}`` dict that
+   :func:`cortexlab.data.studies.lahner2024bold.load_subject` consumes via
+   its ``parcellation=`` kwarg.
+
+2. :func:`load_hcp_mmp_fsaverage` — a convenience loader for the
+   Glasser et al. 2016 HCP-MMP 1.0 parcellation on the fsaverage7
+   surface. Accepts paths to the left- and right-hemisphere ``.annot``
+   files and returns the combined-hemisphere vertex indices for a
+   user-selected subset of ROIs.
+
+The module is intentionally path-agnostic; it does not download atlas
+files. Users point it at ``.annot`` files they already have locally.
+
+Where to get the HCP-MMP fsaverage annot files
+-----------------------------------------------
+
+The official projections are distributed several ways:
+
+* ``$FREESURFER_HOME/subjects/fsaverage/label/lh.HCPMMP1.annot`` (and
+  ``rh.HCPMMP1.annot``) when using the ``--hcp-mmp`` FreeSurfer build.
+* `github.com/faskowit/multiAtlasTT` (atlases repackaged for multiple
+  subjects including fsaverage).
+* `github.com/HolmesLab/Parcellations_onto_fsaverage`.
+
+Any of these work as long as the resulting file parses with
+``nibabel.freesurfer.io.read_annot``.
+
+Default ROI subset for NeuroAI studies
+---------------------------------------
+
+The default selection in :func:`load_hcp_mmp_fsaverage` covers the
+regions most commonly reported in multimodal brain-encoding papers:
+
+* **Early visual**: V1, V2, V3, V4
+* **Lateral occipital**: LO1, LO2, LO3, MT, MST
+* **Category-selective**: FFC (face complex), PH (place-related)
+* **Auditory**: A1, A4, A5
+* **Superior temporal**: STSda, STSdp, STSva, STSvp
+* **Language**: 44, 45 (Broca), IFJa, IFJp, PFm, PGs, PGi (angular /
+  IPL)
+* **Anterior temporal**: TF, TGd, TGv
+
+Callers can ask for any other HCP-MMP region by name via the ``rois``
+argument.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# default ROI set for NeuroAI lesion studies                                  #
+# --------------------------------------------------------------------------- #
+
+DEFAULT_HCP_MMP_ROIS: tuple[str, ...] = (
+    # Early visual hierarchy.
+    "V1", "V2", "V3", "V4",
+    # Lateral occipital / motion-selective.
+    "LO1", "LO2", "LO3", "MT", "MST",
+    # Category-selective.
+    "FFC", "PH",
+    # Auditory.
+    "A1", "A4", "A5",
+    # Superior temporal sulcus subdivisions.
+    "STSda", "STSdp", "STSva", "STSvp",
+    # Classical language.
+    "44", "45", "IFJa", "IFJp",
+    # Angular gyrus / inferior parietal lobule.
+    "PFm", "PGs", "PGi",
+    # Anterior temporal lobe proxies.
+    "TF", "TGd", "TGv",
+)
+"""HCP-MMP ROI names we report by default. Covers the visual / auditory /
+language / multimodal split that NeuroAI encoding papers typically present.
+"""
+
+
+# The HCP-MMP release prefixes each label with ``L_`` or ``R_`` and suffixes
+# with ``_ROI``. Users can pass either the bare region name ("V1") or the
+# fully-qualified form ("L_V1_ROI"); we normalize internally.
+_HCP_MMP_PREFIX: dict[str, str] = {"left": "L_", "right": "R_"}
+_HCP_MMP_SUFFIX: str = "_ROI"
+
+
+# --------------------------------------------------------------------------- #
+# core helper                                                                 #
+# --------------------------------------------------------------------------- #
+
+def build_roi_indices(
+    labels_lh: np.ndarray,
+    names_lh: Sequence[str],
+    labels_rh: np.ndarray,
+    names_rh: Sequence[str],
+    rois: Sequence[str],
+    strict: bool = False,
+) -> dict[str, np.ndarray]:
+    """Convert annot-style labels + names into combined-hemisphere ROI indices.
+
+    The return format matches what
+    :func:`cortexlab.data.studies.lahner2024bold.load_subject` expects for
+    its ``parcellation`` kwarg: each value is a 1-D ``int64`` array of
+    vertex indices into the concatenated ``(left ‖ right)`` cortex, with
+    the right hemisphere offset by ``len(labels_lh)``.
+
+    Parameters
+    ----------
+    labels_lh, labels_rh
+        Integer label arrays, one entry per vertex, typically 163842 for
+        fsaverage7. Each entry indexes into ``names_lh`` / ``names_rh``.
+    names_lh, names_rh
+        Region names indexed by the label values. Exactly the tuple
+        returned by ``nibabel.freesurfer.io.read_annot`` once names are
+        decoded from bytes to str.
+    rois
+        ROI names to include. Can be either bare ("V1") or
+        hemisphere-qualified ("L_V1_ROI"). Matching is done
+        case-insensitively and tolerates the ``L_...`` / ``R_...`` and
+        ``_ROI`` decorations.
+    strict
+        When True, raise ``KeyError`` if a requested ROI matches neither
+        hemisphere. When False, skip missing ROIs with a warning and
+        return what was found.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        ``{roi_name: int64_indices}``. Region names are returned in the
+        bare form (no ``L_`` / ``R_`` / ``_ROI`` decoration); the indices
+        combine both hemispheres.
+
+    Raises
+    ------
+    ValueError
+        If ``labels_lh`` and ``labels_rh`` have different lengths.
+    KeyError
+        If ``strict=True`` and a requested ROI is not found.
+
+    Examples
+    --------
+    >>> labels_lh = np.array([0, 1, 1, 2])          # 4 vertices, 3 regions
+    >>> names_lh = ["L_???", "L_V1_ROI", "L_V2_ROI"]
+    >>> labels_rh = np.array([0, 2, 1, 1])
+    >>> names_rh = ["R_???", "R_V1_ROI", "R_V2_ROI"]
+    >>> idx = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh,
+    ...                         rois=["V1", "V2"])
+    >>> sorted(idx["V1"].tolist())
+    [1, 2, 6, 7]
+    >>> sorted(idx["V2"].tolist())
+    [3, 5]
+    """
+    labels_lh = np.asarray(labels_lh)
+    labels_rh = np.asarray(labels_rh)
+    if labels_lh.ndim != 1 or labels_rh.ndim != 1:
+        raise ValueError("labels arrays must be 1-D")
+    n_lh = int(labels_lh.shape[0])
+
+    name_to_idx_lh = {_canonical(n): i for i, n in enumerate(names_lh)}
+    name_to_idx_rh = {_canonical(n): i for i, n in enumerate(names_rh)}
+
+    out: dict[str, np.ndarray] = {}
+    for roi in rois:
+        canonical = _canonical(roi)
+        pieces: list[np.ndarray] = []
+        if canonical in name_to_idx_lh:
+            lh_label = name_to_idx_lh[canonical]
+            pieces.append(np.where(labels_lh == lh_label)[0].astype(np.int64))
+        if canonical in name_to_idx_rh:
+            rh_label = name_to_idx_rh[canonical]
+            pieces.append(
+                (np.where(labels_rh == rh_label)[0] + n_lh).astype(np.int64)
+            )
+        if not pieces:
+            msg = f"ROI {roi!r} (canonical {canonical!r}) not found in either hemisphere"
+            if strict:
+                raise KeyError(msg)
+            logger.warning(msg + "; skipping")
+            continue
+        combined = np.concatenate(pieces)
+        if combined.size == 0:
+            logger.warning("ROI %r has zero vertices in the annot; skipping", roi)
+            continue
+        out[_friendly(roi)] = np.sort(combined)
+    return out
+
+
+def _canonical(name: str | bytes) -> str:
+    """Normalize a region name to its bare, case-folded form.
+
+    ``L_V1_ROI``, ``R_V1_ROI``, ``V1``, and ``v1`` all canonicalize to
+    ``"v1"`` so that lookups in either hemisphere match regardless of
+    which convention the caller uses.
+    """
+    if isinstance(name, bytes):
+        name = name.decode("utf-8", errors="replace")
+    s = name.strip()
+    for prefix in _HCP_MMP_PREFIX.values():
+        if s.startswith(prefix):
+            s = s[len(prefix):]
+            break
+    if s.endswith(_HCP_MMP_SUFFIX):
+        s = s[: -len(_HCP_MMP_SUFFIX)]
+    return s.casefold()
+
+
+def _friendly(name: str) -> str:
+    """Return a pretty display name for dict keys (strips ``L_`` / ``_ROI``
+    decoration but preserves the user's original case when unambiguous).
+    """
+    s = name.strip()
+    for prefix in _HCP_MMP_PREFIX.values():
+        if s.startswith(prefix):
+            s = s[len(prefix):]
+            break
+    if s.endswith(_HCP_MMP_SUFFIX):
+        s = s[: -len(_HCP_MMP_SUFFIX)]
+    return s
+
+
+# --------------------------------------------------------------------------- #
+# HCP-MMP 1.0 fsaverage convenience loader                                    #
+# --------------------------------------------------------------------------- #
+
+def load_hcp_mmp_fsaverage(
+    lh_annot_path: str | os.PathLike,
+    rh_annot_path: str | os.PathLike,
+    rois: Sequence[str] | None = None,
+    strict: bool = False,
+) -> dict[str, np.ndarray]:
+    """Load HCP-MMP 1.0 ROIs for fsaverage from FreeSurfer ``.annot`` files.
+
+    Parameters
+    ----------
+    lh_annot_path, rh_annot_path
+        Paths to the left- and right-hemisphere annot files. Typically
+        ``fsaverage/label/lh.HCPMMP1.annot`` and ``rh.HCPMMP1.annot``
+        from a FreeSurfer install, or equivalent downloads (see the
+        module docstring for sources).
+    rois
+        Which HCP-MMP region names to include. None uses
+        :data:`DEFAULT_HCP_MMP_ROIS`. Region names can be given with or
+        without the ``L_`` / ``R_`` prefix and ``_ROI`` suffix.
+    strict
+        Forwarded to :func:`build_roi_indices`.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        Maps each ROI name to its combined-hemisphere vertex indices.
+        Ready to pass as ``parcellation=`` to ``load_subject``.
+
+    Notes
+    -----
+    This function uses ``nibabel.freesurfer.io.read_annot``, which
+    returns the label array, the RGBA color table, and the list of
+    region names. Only the labels and names are used here.
+    """
+    try:
+        import nibabel.freesurfer.io as fsio  # noqa: WPS433  (lazy dep)
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "load_hcp_mmp_fsaverage requires nibabel. Install it with "
+            "`pip install nibabel`, or install the [analysis] extras."
+        ) from e
+
+    lh_path = Path(lh_annot_path)
+    rh_path = Path(rh_annot_path)
+    if not lh_path.exists():
+        raise FileNotFoundError(f"left annot file not found: {lh_path}")
+    if not rh_path.exists():
+        raise FileNotFoundError(f"right annot file not found: {rh_path}")
+
+    labels_lh, _ctab_lh, names_lh_b = fsio.read_annot(str(lh_path))
+    labels_rh, _ctab_rh, names_rh_b = fsio.read_annot(str(rh_path))
+    # nibabel returns bytes in `names` until 5.x; handle both.
+    names_lh = [n.decode("utf-8", errors="replace") if isinstance(n, bytes) else n
+                for n in names_lh_b]
+    names_rh = [n.decode("utf-8", errors="replace") if isinstance(n, bytes) else n
+                for n in names_rh_b]
+
+    target_rois = tuple(rois) if rois is not None else DEFAULT_HCP_MMP_ROIS
+    roi_indices = build_roi_indices(
+        labels_lh, names_lh, labels_rh, names_rh,
+        rois=target_rois, strict=strict,
+    )
+    logger.info(
+        "loaded HCP-MMP fsaverage parcellation: %d ROIs recovered from %s + %s",
+        len(roi_indices), lh_path.name, rh_path.name,
+    )
+    return roi_indices
+
+
+# --------------------------------------------------------------------------- #
+# env-based convenience                                                       #
+# --------------------------------------------------------------------------- #
+
+def load_hcp_mmp_from_freesurfer(
+    subjects_dir: str | os.PathLike | None = None,
+    subject: str = "fsaverage",
+    rois: Sequence[str] | None = None,
+    strict: bool = False,
+) -> dict[str, np.ndarray]:
+    """Load HCP-MMP from a standard FreeSurfer ``SUBJECTS_DIR`` layout.
+
+    Convenience wrapper around :func:`load_hcp_mmp_fsaverage` that looks
+    for ``{subjects_dir}/{subject}/label/{lh,rh}.HCPMMP1.annot``.
+
+    Parameters
+    ----------
+    subjects_dir
+        Path to FreeSurfer's ``SUBJECTS_DIR``. Falls back to the
+        environment variable of the same name when None.
+    subject
+        Subject directory name. ``"fsaverage"`` for the standard
+        template; use a subject ID for per-subject cortical surfaces.
+    rois, strict
+        Forwarded to :func:`load_hcp_mmp_fsaverage`.
+    """
+    if subjects_dir is None:
+        env = os.environ.get("SUBJECTS_DIR")
+        if not env:
+            raise RuntimeError(
+                "subjects_dir not given and SUBJECTS_DIR env var is unset"
+            )
+        subjects_dir = env
+    root = Path(subjects_dir) / subject / "label"
+    return load_hcp_mmp_fsaverage(
+        lh_annot_path=root / "lh.HCPMMP1.annot",
+        rh_annot_path=root / "rh.HCPMMP1.annot",
+        rois=rois,
+        strict=strict,
+    )
+
+
+__all__ = [
+    "DEFAULT_HCP_MMP_ROIS",
+    "build_roi_indices",
+    "load_hcp_mmp_fsaverage",
+    "load_hcp_mmp_from_freesurfer",
+]

--- a/tests/test_parcellations.py
+++ b/tests/test_parcellations.py
@@ -14,14 +14,13 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
+from cortexlab.data import parcellations as pmod
 from cortexlab.data.parcellations import (
     DEFAULT_HCP_MMP_ROIS,
     build_roi_indices,
-    load_hcp_mmp_fsaverage,
     load_hcp_mmp_from_freesurfer,
+    load_hcp_mmp_fsaverage,
 )
-from cortexlab.data import parcellations as pmod
-
 
 # --------------------------------------------------------------------------- #
 # default ROI set                                                             #

--- a/tests/test_parcellations.py
+++ b/tests/test_parcellations.py
@@ -1,0 +1,381 @@
+"""Tests for :mod:`cortexlab.data.parcellations`.
+
+Synthetic annot-style arrays cover every branch of ``build_roi_indices``
+and the HCP-MMP convenience loaders. No on-disk atlas required.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from cortexlab.data.parcellations import (
+    DEFAULT_HCP_MMP_ROIS,
+    build_roi_indices,
+    load_hcp_mmp_fsaverage,
+    load_hcp_mmp_from_freesurfer,
+)
+from cortexlab.data import parcellations as pmod
+
+
+# --------------------------------------------------------------------------- #
+# default ROI set                                                             #
+# --------------------------------------------------------------------------- #
+
+def test_default_roi_set_covers_pillars():
+    """The default set should include at least one ROI from each of the
+    visual / auditory / language pillars a NeuroAI paper needs."""
+    s = set(DEFAULT_HCP_MMP_ROIS)
+    assert {"V1", "V2", "V4"} <= s            # early visual
+    assert {"MT", "MST"} <= s                  # motion
+    assert {"FFC"} <= s                        # face complex
+    assert {"A1"} <= s                         # auditory
+    assert {"44", "45"} <= s                   # Broca
+    assert {"PGs", "PGi"} <= s                 # angular gyrus
+
+
+def test_default_roi_set_has_no_duplicates():
+    assert len(DEFAULT_HCP_MMP_ROIS) == len(set(DEFAULT_HCP_MMP_ROIS))
+
+
+# --------------------------------------------------------------------------- #
+# build_roi_indices — happy paths                                             #
+# --------------------------------------------------------------------------- #
+
+def _fake_lh_rh():
+    """A minimal synthetic bihemispheric annot.
+
+    Left hemisphere has 4 vertices labeled [0, 1, 1, 2].
+    Right hemisphere has 4 vertices labeled [0, 2, 1, 1].
+
+    Region 0 is the unknown/???
+    Region 1 is V1
+    Region 2 is V2
+    """
+    labels_lh = np.array([0, 1, 1, 2], dtype=np.int32)
+    names_lh = ["L_???", "L_V1_ROI", "L_V2_ROI"]
+    labels_rh = np.array([0, 2, 1, 1], dtype=np.int32)
+    names_rh = ["R_???", "R_V1_ROI", "R_V2_ROI"]
+    return labels_lh, names_lh, labels_rh, names_rh
+
+
+def test_build_roi_indices_happy_path():
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(
+        labels_lh, names_lh, labels_rh, names_rh,
+        rois=["V1", "V2"],
+    )
+    # V1 is label 1 in LH (vertices 1, 2) and label 1 in RH (vertices 2, 3).
+    # Right hemisphere indices are offset by n_lh = 4.
+    assert sorted(out["V1"].tolist()) == [1, 2, 6, 7]
+    # V2 is label 2 in LH (vertex 3) and label 2 in RH (vertex 1).
+    assert sorted(out["V2"].tolist()) == [3, 5]
+
+
+def test_build_roi_indices_dtype_is_int64():
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    assert out["V1"].dtype == np.int64
+
+
+def test_build_roi_indices_is_sorted():
+    """Indices should be sorted so downstream slicing has no surprises."""
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    arr = out["V1"]
+    assert np.all(arr[:-1] <= arr[1:])
+
+
+def test_build_roi_indices_right_offset_correct():
+    """Right hemisphere vertex K must land at index K + n_lh in the output."""
+    # LH has 10 vertices, all background.
+    labels_lh = np.zeros(10, dtype=np.int32)
+    names_lh = ["L_???", "L_V1_ROI"]
+    # RH has 4 vertices, last one is V1.
+    labels_rh = np.array([0, 0, 0, 1], dtype=np.int32)
+    names_rh = ["R_???", "R_V1_ROI"]
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    assert out["V1"].tolist() == [13]      # 10 + 3
+
+
+# --------------------------------------------------------------------------- #
+# name normalization: prefix / suffix / case                                  #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("roi_name", ["V1", "v1", "L_V1_ROI", "R_V1_ROI", " V1 "])
+def test_build_roi_indices_matches_regardless_of_decoration(roi_name):
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(
+        labels_lh, names_lh, labels_rh, names_rh, rois=[roi_name],
+    )
+    # Should match V1 in both hemispheres regardless of how the caller spelled it.
+    assert len(out) == 1
+    only_key = next(iter(out))
+    assert sorted(out[only_key].tolist()) == [1, 2, 6, 7]
+
+
+def test_build_roi_indices_tolerates_bytes_names():
+    """nibabel < 5 returns bytes; build_roi_indices should not care."""
+    labels_lh = np.array([0, 1], dtype=np.int32)
+    names_lh = [b"L_???", b"L_V1_ROI"]
+    labels_rh = np.array([0, 1], dtype=np.int32)
+    names_rh = [b"R_???", b"R_V1_ROI"]
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    assert out["V1"].tolist() == [1, 3]    # LH vertex 1, RH vertex 1 + n_lh(2)
+
+
+# --------------------------------------------------------------------------- #
+# missing / zero-vertex ROIs                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_build_roi_indices_missing_strict_raises():
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    with pytest.raises(KeyError, match="not found"):
+        build_roi_indices(
+            labels_lh, names_lh, labels_rh, names_rh,
+            rois=["V1", "FFC"], strict=True,
+        )
+
+
+def test_build_roi_indices_missing_non_strict_skips_and_warns(caplog):
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    with caplog.at_level(logging.WARNING, logger="cortexlab.data.parcellations"):
+        out = build_roi_indices(
+            labels_lh, names_lh, labels_rh, names_rh,
+            rois=["V1", "FFC"], strict=False,
+        )
+    assert "V1" in out
+    assert "FFC" not in out
+    assert any("FFC" in r.message for r in caplog.records)
+
+
+def test_build_roi_indices_one_hemisphere_only_is_fine():
+    """If an ROI exists only in LH (unusual but possible), the returned
+    indices cover just that hemisphere."""
+    labels_lh = np.array([0, 1, 1], dtype=np.int32)
+    names_lh = ["L_???", "L_V1_ROI"]
+    labels_rh = np.array([0, 0], dtype=np.int32)
+    names_rh = ["R_???"]
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    assert out["V1"].tolist() == [1, 2]
+
+
+def test_build_roi_indices_zero_vertex_roi_is_skipped(caplog):
+    """A region name that's listed but has no vertices labeled with it
+    should be skipped rather than returning an empty array (downstream
+    code treats zero-size arrays as errors)."""
+    labels_lh = np.array([0, 0, 0], dtype=np.int32)
+    names_lh = ["L_???", "L_V1_ROI"]   # V1 declared but never labeled
+    labels_rh = np.array([0, 0, 0], dtype=np.int32)
+    names_rh = ["R_???", "R_V1_ROI"]
+    with caplog.at_level(logging.WARNING, logger="cortexlab.data.parcellations"):
+        out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    assert "V1" not in out
+    assert any("zero vertices" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# shape / input validation                                                    #
+# --------------------------------------------------------------------------- #
+
+def test_build_roi_indices_rejects_2d_labels():
+    labels_lh = np.zeros((3, 3), dtype=np.int32)
+    with pytest.raises(ValueError, match="1-D"):
+        build_roi_indices(
+            labels_lh, ["L_???"], np.zeros(3, dtype=np.int32), ["R_???"],
+            rois=["V1"],
+        )
+
+
+def test_build_roi_indices_empty_rois_returns_empty_dict():
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=[])
+    assert out == {}
+
+
+# --------------------------------------------------------------------------- #
+# integration with load_subject's contract                                    #
+# --------------------------------------------------------------------------- #
+
+def test_result_is_loadable_as_parcellation_kwarg():
+    """The dict shape must be {str: int64 ndarray} so load_subject accepts it."""
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(
+        labels_lh, names_lh, labels_rh, names_rh, rois=["V1", "V2"],
+    )
+    assert isinstance(out, dict)
+    for key, val in out.items():
+        assert isinstance(key, str)
+        assert isinstance(val, np.ndarray)
+        assert val.dtype == np.int64
+        assert val.ndim == 1
+
+
+# --------------------------------------------------------------------------- #
+# load_hcp_mmp_fsaverage (monkeypatched read_annot)                           #
+# --------------------------------------------------------------------------- #
+
+def _install_fake_nibabel(monkeypatch, annots: dict[Path, tuple]):
+    """Install a fake nibabel.freesurfer.io.read_annot that returns the
+    annot tuple for whichever path the caller gives."""
+    calls: list[str] = []
+
+    def fake_read_annot(path: str):
+        calls.append(path)
+        return annots[Path(path)]
+
+    fake_fsio = SimpleNamespace(read_annot=fake_read_annot)
+    fake_freesurfer = SimpleNamespace(io=fake_fsio)
+    fake_nibabel = SimpleNamespace(freesurfer=fake_freesurfer)
+
+    monkeypatch.setitem(sys.modules, "nibabel", fake_nibabel)
+    monkeypatch.setitem(sys.modules, "nibabel.freesurfer", fake_freesurfer)
+    monkeypatch.setitem(sys.modules, "nibabel.freesurfer.io", fake_fsio)
+    return calls
+
+
+def test_load_hcp_mmp_fsaverage_happy(tmp_path, monkeypatch):
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    lh_path = tmp_path / "lh.HCPMMP1.annot"
+    rh_path = tmp_path / "rh.HCPMMP1.annot"
+    lh_path.write_bytes(b"")
+    rh_path.write_bytes(b"")
+
+    ctab = np.zeros((3, 5), dtype=np.int32)
+    annots = {
+        lh_path: (labels_lh, ctab, [n.encode() for n in names_lh]),
+        rh_path: (labels_rh, ctab, [n.encode() for n in names_rh]),
+    }
+    _install_fake_nibabel(monkeypatch, annots)
+
+    out = load_hcp_mmp_fsaverage(lh_path, rh_path, rois=["V1", "V2"])
+    assert set(out.keys()) == {"V1", "V2"}
+    assert sorted(out["V1"].tolist()) == [1, 2, 6, 7]
+
+
+def test_load_hcp_mmp_fsaverage_missing_lh_raises(tmp_path, monkeypatch):
+    rh_path = tmp_path / "rh.HCPMMP1.annot"
+    rh_path.write_bytes(b"")
+    _install_fake_nibabel(monkeypatch, {})
+    with pytest.raises(FileNotFoundError, match="left"):
+        load_hcp_mmp_fsaverage(tmp_path / "missing.annot", rh_path)
+
+
+def test_load_hcp_mmp_fsaverage_missing_rh_raises(tmp_path, monkeypatch):
+    lh_path = tmp_path / "lh.HCPMMP1.annot"
+    lh_path.write_bytes(b"")
+    _install_fake_nibabel(monkeypatch, {})
+    with pytest.raises(FileNotFoundError, match="right"):
+        load_hcp_mmp_fsaverage(lh_path, tmp_path / "missing.annot")
+
+
+def test_load_hcp_mmp_fsaverage_default_rois(tmp_path, monkeypatch):
+    """When rois=None, the loader tries every DEFAULT_HCP_MMP_ROIS name.
+    Absent regions are skipped (non-strict)."""
+    # Build a minimal annot that contains V1 only.
+    labels_lh = np.array([0, 1], dtype=np.int32)
+    names_lh = ["L_???", "L_V1_ROI"]
+    labels_rh = np.array([0, 1], dtype=np.int32)
+    names_rh = ["R_???", "R_V1_ROI"]
+
+    lh_path = tmp_path / "lh.HCPMMP1.annot"
+    rh_path = tmp_path / "rh.HCPMMP1.annot"
+    lh_path.write_bytes(b"")
+    rh_path.write_bytes(b"")
+
+    ctab = np.zeros((2, 5), dtype=np.int32)
+    annots = {
+        lh_path: (labels_lh, ctab, [n.encode() for n in names_lh]),
+        rh_path: (labels_rh, ctab, [n.encode() for n in names_rh]),
+    }
+    _install_fake_nibabel(monkeypatch, annots)
+
+    out = load_hcp_mmp_fsaverage(lh_path, rh_path)      # rois=None
+    assert "V1" in out
+    # Everything else in DEFAULT_HCP_MMP_ROIS is absent in our tiny annot.
+    assert set(out.keys()) == {"V1"}
+
+
+# --------------------------------------------------------------------------- #
+# load_hcp_mmp_from_freesurfer (SUBJECTS_DIR)                                 #
+# --------------------------------------------------------------------------- #
+
+def test_load_hcp_mmp_from_freesurfer_uses_subjects_dir(tmp_path, monkeypatch):
+    subj_root = tmp_path / "subjects" / "fsaverage" / "label"
+    subj_root.mkdir(parents=True)
+    lh_path = subj_root / "lh.HCPMMP1.annot"
+    rh_path = subj_root / "rh.HCPMMP1.annot"
+    lh_path.write_bytes(b"")
+    rh_path.write_bytes(b"")
+
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    ctab = np.zeros((3, 5), dtype=np.int32)
+    annots = {
+        lh_path: (labels_lh, ctab, [n.encode() for n in names_lh]),
+        rh_path: (labels_rh, ctab, [n.encode() for n in names_rh]),
+    }
+    _install_fake_nibabel(monkeypatch, annots)
+
+    out = load_hcp_mmp_from_freesurfer(
+        subjects_dir=tmp_path / "subjects", rois=["V1"],
+    )
+    assert "V1" in out
+
+
+def test_load_hcp_mmp_from_freesurfer_falls_back_to_env(tmp_path, monkeypatch):
+    subj_root = tmp_path / "subjects" / "fsaverage" / "label"
+    subj_root.mkdir(parents=True)
+    lh_path = subj_root / "lh.HCPMMP1.annot"
+    rh_path = subj_root / "rh.HCPMMP1.annot"
+    lh_path.write_bytes(b"")
+    rh_path.write_bytes(b"")
+
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    ctab = np.zeros((3, 5), dtype=np.int32)
+    annots = {
+        lh_path: (labels_lh, ctab, [n.encode() for n in names_lh]),
+        rh_path: (labels_rh, ctab, [n.encode() for n in names_rh]),
+    }
+    _install_fake_nibabel(monkeypatch, annots)
+
+    monkeypatch.setenv("SUBJECTS_DIR", str(tmp_path / "subjects"))
+    out = load_hcp_mmp_from_freesurfer(rois=["V1"])
+    assert "V1" in out
+
+
+def test_load_hcp_mmp_from_freesurfer_no_env_raises(monkeypatch):
+    monkeypatch.delenv("SUBJECTS_DIR", raising=False)
+    with pytest.raises(RuntimeError, match="SUBJECTS_DIR"):
+        load_hcp_mmp_from_freesurfer()
+
+
+# --------------------------------------------------------------------------- #
+# internal helpers (exercised indirectly above, but pinning behavior)         #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("name,expected", [
+    ("V1", "v1"),
+    ("L_V1_ROI", "v1"),
+    ("R_V1_ROI", "v1"),
+    ("  v1  ", "v1"),
+    ("L_FFC_ROI", "ffc"),
+    ("44", "44"),
+    (b"L_V1_ROI", "v1"),
+])
+def test_canonical_normalizes(name, expected):
+    assert pmod._canonical(name) == expected
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("V1", "V1"),
+    ("L_V1_ROI", "V1"),
+    ("R_FFC_ROI", "FFC"),
+    ("44", "44"),
+])
+def test_friendly_strips_decoration_preserves_case(name, expected):
+    assert pmod._friendly(name) == expected


### PR DESCRIPTION
## Summary

Adds cortical-parcellation support so per-ROI statistics (V1, V4, MT, FFC, A1, 44/45, PGs, ...) replace the single \`all_cortex\` bucket when reporting encoding / lesion results.

- \`cortexlab.data.parcellations.build_roi_indices\` is the atlas-agnostic workhorse. It accepts FreeSurfer \`.annot\` style \`(labels, names)\` for both hemispheres and returns a \`{roi_name: int64 indices}\` dict, with the right hemisphere correctly offset by \`len(labels_lh)\`. The output format is exactly what \`load_subject(parcellation=...)\` already consumes, so no changes were needed there.
- \`load_hcp_mmp_fsaverage(lh_annot, rh_annot, rois=None)\` wraps \`nibabel.freesurfer.io.read_annot\` for the standard HCP-MMP 1.0 fsaverage layout.
- \`load_hcp_mmp_from_freesurfer(subjects_dir, subject)\` is a thin \`SUBJECTS_DIR\`-aware convenience on top.
- \`DEFAULT_HCP_MMP_ROIS\` covers the 29 regions that multimodal-encoding papers most commonly report: V1/V2/V3/V4, LO1-3, MT/MST, FFC, PH, A1/A4/A5, STSda/dp/va/vp, 44/45/IFJa/IFJp, PFm/PGs/PGi, TF/TGd/TGv. Callers can override with \`rois=...\`.
- Name matching tolerates the \`L_\` / \`R_\` prefix and \`_ROI\` suffix and is case-insensitive, so any of \`V1\`, \`v1\`, \`L_V1_ROI\` resolve to the same region.
- \`experiments/causal_modality_ablation.py\` grows four new CLI flags (\`--parcellation\`, \`--lh-annot\`, \`--rh-annot\`, \`--parcellation-rois\`). The parcellation is loaded exactly once per run and threaded into \`load_subject\` for every subject.
- 37 new unit tests cover: happy path, hemisphere offset, dtype (int64), sortedness, \`L_\`/\`R_\`/\`_ROI\` tolerance, case-folding, bytes-name compatibility (nibabel < 5), strict vs. non-strict missing ROI, zero-vertex warning, 1-D input validation, empty ROI list, both loader wrappers with monkeypatched \`nibabel\`, and \`SUBJECTS_DIR\` fallback.

No atlas files are committed; the module is path-agnostic and the docstring points at three common sources (FreeSurfer \`--hcp-mmp\` build, faskowit/multiAtlasTT, HolmesLab/Parcellations_onto_fsaverage).

## Test plan

- [x] \`python -m pytest tests/test_parcellations.py -v\` -> 37 passed
- [x] \`python -m pytest tests/ -q\` -> 217 passed, 3 skipped (no regressions)
- [x] \`python -m experiments.causal_modality_ablation --help\` shows the four new flags
- [x] \`python -m experiments.causal_modality_ablation --mock --subjects 1 --pilot 50 ...\` still runs end-to-end on CPU
- [ ] Real run on Jarvis with \`--parcellation hcp-mmp --lh-annot lh.HCPMMP1.annot --rh-annot rh.HCPMMP1.annot\` once atlas files are staged