### PR TITLE
feat(analysis): row-permutation test per modality for lesion

### DIFF
--- a/experiments/causal_modality_ablation.py
+++ b/experiments/causal_modality_ablation.py
@@ -88,6 +88,19 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--modalities", type=str, default="vision,text",
                     help="Comma-separated modality names whose .npz files "
                          "live in --feature-cache.")
+    ap.add_argument("--parcellation", type=str, default="none",
+                    choices=["none", "hcp-mmp"],
+                    help="Parcellation to report ROI-level results against. "
+                         "'none' keeps a single 'all_cortex' bucket. "
+                         "'hcp-mmp' requires --lh-annot and --rh-annot.")
+    ap.add_argument("--lh-annot", type=str, default=None,
+                    help="Left-hemisphere FreeSurfer .annot file for the "
+                         "HCP-MMP (or compatible) parcellation.")
+    ap.add_argument("--rh-annot", type=str, default=None,
+                    help="Right-hemisphere FreeSurfer .annot file.")
+    ap.add_argument("--parcellation-rois", type=str, default=None,
+                    help="Comma-separated ROI names to include. None uses the "
+                         "DEFAULT_HCP_MMP_ROIS set from cortexlab.data.parcellations.")
     return ap.parse_args()
 
 
@@ -102,8 +115,33 @@ def _load_config(path: str | None) -> dict:
 # data loading                                                                #
 # --------------------------------------------------------------------------- #
 
+def _resolve_parcellation(cfg: dict) -> dict[str, np.ndarray] | None:
+    """Build the ``{roi_name: indices}`` dict from CLI/yaml config, or None.
+
+    Separated from ``_load_subject_data`` so the parcellation is loaded
+    exactly once and shared across subjects (the annot files are identical
+    for every subject on fsaverage).
+    """
+    kind = cfg.get("parcellation") or "none"
+    if kind == "none":
+        return None
+    if kind == "hcp-mmp":
+        from cortexlab.data.parcellations import load_hcp_mmp_fsaverage  # lazy
+        lh = cfg.get("lh_annot")
+        rh = cfg.get("rh_annot")
+        if not lh or not rh:
+            raise ValueError(
+                "parcellation=hcp-mmp requires --lh-annot and --rh-annot "
+                "(or the equivalent yaml keys lh_annot / rh_annot)."
+            )
+        rois = cfg.get("parcellation_rois")
+        return load_hcp_mmp_fsaverage(lh, rh, rois=rois)
+    raise ValueError(f"unknown parcellation {kind!r}")
+
+
 def _load_subject_data(
     subject_id: int, cfg: dict, pilot: int | None,
+    parcellation: dict[str, np.ndarray] | None = None,
 ) -> dict:
     """Load features and responses for one subject.
 
@@ -113,7 +151,9 @@ def _load_subject_data(
     data came from disk or from the mock generator.
 
     ``cfg`` is the merged configuration (YAML plus CLI overrides), so the
-    helper does not need to know which source set each field.
+    helper does not need to know which source set each field. ``parcellation``
+    is threaded through to ``load_subject`` so per-ROI aggregation is done
+    downstream in the orchestrator.
     """
     from cortexlab.data.studies.lahner2024bold import load_subject  # lazy
 
@@ -123,6 +163,7 @@ def _load_subject_data(
         root=cfg.get("data_root"),
         feature_cache=cfg.get("feature_cache"),
         modalities=tuple(modalities),
+        parcellation=parcellation,
         n_trimmed_stimuli=pilot,
     )
     return rec
@@ -230,9 +271,19 @@ def run_study(
     lesion_objs: dict[int, LesionResult] = {}
     responses_for_ceiling = []
 
+    # Parcellation is shared across subjects; load once. Mock mode keeps
+    # its synthetic per-modality ROI bucket regardless.
+    parcellation = None if mock else _resolve_parcellation(cfg)
+    if parcellation is not None:
+        logger.info("parcellation loaded: %d ROIs", len(parcellation))
+
     for sid in subject_ids:
         logger.info("loading subject %d", sid)
-        rec = _mock_subject_data(sid) if mock else _load_subject_data(sid, cfg, pilot)
+        rec = (
+            _mock_subject_data(sid)
+            if mock
+            else _load_subject_data(sid, cfg, pilot, parcellation=parcellation)
+        )
         summary, lesion = run_one_subject(
             rec, alphas=alphas, cv=cv, mask=mask,
             device=device, backend=backend,
@@ -304,6 +355,16 @@ def main() -> None:
         cfg["feature_cache"] = args.feature_cache
     if args.modalities:
         cfg["modalities"] = [m.strip() for m in args.modalities.split(",") if m.strip()]
+    if args.parcellation:
+        cfg["parcellation"] = args.parcellation
+    if args.lh_annot is not None:
+        cfg["lh_annot"] = args.lh_annot
+    if args.rh_annot is not None:
+        cfg["rh_annot"] = args.rh_annot
+    if args.parcellation_rois:
+        cfg["parcellation_rois"] = [
+            r.strip() for r in args.parcellation_rois.split(",") if r.strip()
+        ]
 
     alphas = [float(a) for a in args.alphas.split(",")]
 

--- a/experiments/causal_modality_ablation.py
+++ b/experiments/causal_modality_ablation.py
@@ -114,6 +114,12 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--noise-ceiling-split", type=str, default="test",
                     choices=["train", "test"],
                     help="Which split's on-disk ceiling to load from BOLD Moments.")
+    ap.add_argument("--permutations", type=int, default=0,
+                    help="If >0, run a row-permutation test per modality with "
+                         "this many shuffles; p-values land in roi_summary "
+                         "as p_<m>_median and frac_sig_<m>. 0 skips.")
+    ap.add_argument("--permutation-seed", type=int, default=0,
+                    help="RNG seed for reproducible permutations.")
     return ap.parse_args()
 
 
@@ -237,6 +243,8 @@ def run_one_subject(
     device: str,
     backend: str,
     ceiling: np.ndarray | None = None,
+    n_permutations: int = 0,
+    permutation_seed: int = 0,
 ) -> dict:
     """Fit encoder, run lesion, summarize over ROIs.
 
@@ -251,6 +259,8 @@ def run_one_subject(
         rec["y_train"], rec["y_test"],
         alphas=alphas, cv=cv, mask_strategy=mask,
         device=device, backend=backend,
+        n_permutations=n_permutations,
+        permutation_seed=permutation_seed,
     )
     elapsed = time.perf_counter() - t0
     logger.info("subject %s: lesion done in %.1fs", rec["subject_id"], elapsed)
@@ -281,6 +291,16 @@ def run_one_subject(
         else:
             payload["full_r2_normalized_mean"] = float("nan")
         payload["ceiling_mean"] = float(ceiling.mean())
+    if result.p_values is not None:
+        payload["n_permutations"] = result.n_permutations
+        payload["p_value_medians"] = {
+            m: float(result.p_values[m].median().item())
+            for m in result.modality_order
+        }
+        payload["frac_sig_at_05"] = {
+            m: float((result.p_values[m] < 0.05).float().mean().item())
+            for m in result.modality_order
+        }
     return payload, result
 
 
@@ -335,6 +355,8 @@ def run_study(
             rec, alphas=alphas, cv=cv, mask=mask,
             device=device, backend=backend,
             ceiling=ondisk_ceilings.get(sid),
+            n_permutations=int(cfg.get("permutations") or 0),
+            permutation_seed=int(cfg.get("permutation_seed") or 0),
         )
         per_subject.append(summary)
         lesion_objs[sid] = lesion
@@ -364,6 +386,9 @@ def run_study(
                 s_summary["roi_summary"] = roi_summary(
                     lesion_objs[sid], roi_by_subject[sid], ceiling=ceil,
                 )
+                # Re-attach per-ROI permutation fields (roi_summary
+                # re-reads result.p_values on every call, so this is a
+                # no-op when permutations=0).
 
     # Persist per-subject on-disk ceilings for downstream notebooks.
     for sid, ceiling in ondisk_ceilings.items():
@@ -387,13 +412,18 @@ def run_study(
 
     # Also save per-subject raw LesionResult arrays for downstream viz.
     for sid, lr in lesion_objs.items():
-        np.savez_compressed(
-            output_dir / f"subject_{sid:02d}_lesion.npz",
-            full_r2=lr.full_r2.cpu().numpy(),
+        arrays = {
+            "full_r2": lr.full_r2.cpu().numpy(),
+            "best_alpha": lr.best_alpha.cpu().numpy(),
             **{f"delta_{m}": lr.delta_r2[m].cpu().numpy()
                for m in lr.modality_order},
-            best_alpha=lr.best_alpha.cpu().numpy(),
-        )
+        }
+        if lr.p_values is not None:
+            arrays.update({
+                f"p_{m}": lr.p_values[m].cpu().numpy()
+                for m in lr.modality_order
+            })
+        np.savez_compressed(output_dir / f"subject_{sid:02d}_lesion.npz", **arrays)
 
     logger.info("wrote %d subject result(s) to %s",
                 len(subject_ids), output_dir)
@@ -435,6 +465,10 @@ def main() -> None:
         cfg["parcellation_rois"] = [
             r.strip() for r in args.parcellation_rois.split(",") if r.strip()
         ]
+    if args.permutations is not None:
+        cfg["permutations"] = args.permutations
+    if args.permutation_seed is not None:
+        cfg["permutation_seed"] = args.permutation_seed
 
     alphas = [float(a) for a in args.alphas.split(",")]
 

--- a/experiments/causal_modality_ablation.py
+++ b/experiments/causal_modality_ablation.py
@@ -41,6 +41,7 @@ import argparse
 import json
 import logging
 import time
+from collections.abc import Mapping
 from dataclasses import asdict
 from pathlib import Path
 
@@ -101,6 +102,18 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--parcellation-rois", type=str, default=None,
                     help="Comma-separated ROI names to include. None uses the "
                          "DEFAULT_HCP_MMP_ROIS set from cortexlab.data.parcellations.")
+    ap.add_argument("--noise-ceiling", type=str, default="none",
+                    choices=["none", "bold-moments", "inter-subject"],
+                    help="Source of per-voxel noise ceiling used to report "
+                         "normalized R^2. 'bold-moments' loads the authors' "
+                         "pre-computed per-subject n-10 ceiling. 'inter-subject' "
+                         "computes the leave-one-subject-out ceiling from the "
+                         "loaded subjects (requires >=2). 'none' skips.")
+    ap.add_argument("--noise-ceiling-n", type=int, default=10,
+                    help="The 'n' suffix of the BOLD Moments ceiling pickle.")
+    ap.add_argument("--noise-ceiling-split", type=str, default="test",
+                    choices=["train", "test"],
+                    help="Which split's on-disk ceiling to load from BOLD Moments.")
     return ap.parse_args()
 
 
@@ -223,8 +236,15 @@ def run_one_subject(
     mask: str,
     device: str,
     backend: str,
+    ceiling: np.ndarray | None = None,
 ) -> dict:
-    """Fit encoder, run lesion, summarize over ROIs."""
+    """Fit encoder, run lesion, summarize over ROIs.
+
+    When ``ceiling`` is provided it is a per-voxel R^2 ceiling aligned
+    with ``rec["y_test"]``'s voxel axis; it flows into
+    :func:`roi_summary` so each ROI row gains a ``full_r2_normalized``
+    column and the top-level summary gains a ``full_r2_normalized_mean``.
+    """
     t0 = time.perf_counter()
     result = run_modality_lesion(
         rec["features_train"], rec["features_test"],
@@ -235,8 +255,8 @@ def run_one_subject(
     elapsed = time.perf_counter() - t0
     logger.info("subject %s: lesion done in %.1fs", rec["subject_id"], elapsed)
 
-    summary = roi_summary(result, rec["roi_indices"])
-    return {
+    summary = roi_summary(result, rec["roi_indices"], ceiling=ceiling)
+    payload = {
         "subject_id": rec["subject_id"],
         "elapsed_sec": elapsed,
         "n_train": result.n_train,
@@ -250,7 +270,18 @@ def run_one_subject(
             for m in result.modality_order
         },
         "modality_order": result.modality_order,
-    }, result
+    }
+    if ceiling is not None:
+        full_np = result.full_r2.cpu().numpy()
+        mask_vox = ceiling > 0.01
+        if mask_vox.any():
+            payload["full_r2_normalized_mean"] = float(
+                (full_np[mask_vox] / ceiling[mask_vox]).mean()
+            )
+        else:
+            payload["full_r2_normalized_mean"] = float("nan")
+        payload["ceiling_mean"] = float(ceiling.mean())
+    return payload, result
 
 
 def run_study(
@@ -269,6 +300,7 @@ def run_study(
     output_dir.mkdir(parents=True, exist_ok=True)
     per_subject = []
     lesion_objs: dict[int, LesionResult] = {}
+    roi_by_subject: dict[int, Mapping[str, np.ndarray]] = {}
     responses_for_ceiling = []
 
     # Parcellation is shared across subjects; load once. Mock mode keeps
@@ -276,6 +308,21 @@ def run_study(
     parcellation = None if mock else _resolve_parcellation(cfg)
     if parcellation is not None:
         logger.info("parcellation loaded: %d ROIs", len(parcellation))
+
+    # Pre-load per-subject on-disk ceilings when requested. For the
+    # inter-subject ceiling we have to wait until all responses are in
+    # memory; it is applied in a post-processing pass below.
+    ceiling_source = (cfg.get("noise_ceiling") or "none") if not mock else "none"
+    ondisk_ceilings: dict[int, np.ndarray] = {}
+    if ceiling_source == "bold-moments" and not mock:
+        from cortexlab.data.studies.lahner2024bold import load_noise_ceiling  # lazy
+        nc_split = cfg.get("noise_ceiling_split") or "test"
+        nc_n = int(cfg.get("noise_ceiling_n") or 10)
+        for sid in subject_ids:
+            ondisk_ceilings[sid] = load_noise_ceiling(
+                subject_id=sid, root=cfg.get("data_root"),
+                split=nc_split, n=nc_n,
+            )
 
     for sid in subject_ids:
         logger.info("loading subject %d", sid)
@@ -287,24 +334,40 @@ def run_study(
         summary, lesion = run_one_subject(
             rec, alphas=alphas, cv=cv, mask=mask,
             device=device, backend=backend,
+            ceiling=ondisk_ceilings.get(sid),
         )
         per_subject.append(summary)
         lesion_objs[sid] = lesion
+        roi_by_subject[sid] = rec["roi_indices"]
         responses_for_ceiling.append(rec["y_test"])
 
-    # Group-level noise ceiling (only meaningful with multiple subjects).
+    # Inter-subject ceiling: computed post-hoc from the loaded responses.
+    # Only runs when explicitly requested (or as a legacy fallback when
+    # more than one subject is loaded and no ceiling source was specified).
     ceiling_mean = None
-    if len(subject_ids) >= 2:
+    want_inter = ceiling_source == "inter-subject" or (
+        ceiling_source == "none" and len(subject_ids) >= 2 and not mock
+    )
+    if want_inter and len(subject_ids) >= 2:
         stack = np.stack(responses_for_ceiling, axis=0)  # (S, n_test, n_vox)
         if stack.shape[0] >= 2:
             ceil = inter_subject_ceiling(stack)
             ceiling_mean = float(ceil.mean())
             np.save(output_dir / "noise_ceiling.npy", ceil)
-            # Re-report normalized scores per subject.
+            # Re-report normalized scores per subject using the whole-group ceiling.
             for s_summary, sid in zip(per_subject, subject_ids):
                 full_r2 = lesion_objs[sid].full_r2.cpu().numpy()
                 normalized = normalize_by_ceiling(full_r2, ceil)
                 s_summary["full_r2_ceiling_normalized_mean"] = float(normalized.mean())
+                # Refresh the per-ROI table with the inter-subject ceiling so
+                # downstream plots don't mix the on-disk and computed variants.
+                s_summary["roi_summary"] = roi_summary(
+                    lesion_objs[sid], roi_by_subject[sid], ceiling=ceil,
+                )
+
+    # Persist per-subject on-disk ceilings for downstream notebooks.
+    for sid, ceiling in ondisk_ceilings.items():
+        np.save(output_dir / f"subject_{sid:02d}_noise_ceiling.npy", ceiling)
 
     manifest = {
         "n_subjects": len(subject_ids),
@@ -318,6 +381,7 @@ def run_study(
         "mock": mock,
         "results": per_subject,
         "group_ceiling_mean": ceiling_mean,
+        "noise_ceiling_source": ceiling_source,
     }
     (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
 
@@ -361,6 +425,12 @@ def main() -> None:
         cfg["lh_annot"] = args.lh_annot
     if args.rh_annot is not None:
         cfg["rh_annot"] = args.rh_annot
+    if args.noise_ceiling:
+        cfg["noise_ceiling"] = args.noise_ceiling
+    if args.noise_ceiling_n is not None:
+        cfg["noise_ceiling_n"] = args.noise_ceiling_n
+    if args.noise_ceiling_split:
+        cfg["noise_ceiling_split"] = args.noise_ceiling_split
     if args.parcellation_rois:
         cfg["parcellation_rois"] = [
             r.strip() for r in args.parcellation_rois.split(",") if r.strip()

--- a/src/cortexlab/analysis/lesion.py
+++ b/src/cortexlab/analysis/lesion.py
@@ -207,6 +207,8 @@ def run_modality_lesion(
 def roi_summary(
     result: LesionResult,
     roi_indices: Mapping[str, np.ndarray],
+    ceiling: np.ndarray | None = None,
+    min_ceiling: float = 0.01,
 ) -> dict[str, dict[str, float]]:
     """Aggregate a LesionResult over ROIs.
 
@@ -217,20 +219,48 @@ def roi_summary(
     roi_indices
         Mapping ROI name to numpy array of voxel indices (as in the
         project's ``roi_indices`` fixture).
+    ceiling
+        Optional per-voxel noise ceiling in R^2 space, shape
+        ``(n_voxels,)``. When provided, each ROI row gains a
+        ``full_r2_normalized`` entry (model R^2 divided by ceiling per
+        voxel, averaged over the ROI) and a ``ceiling_mean`` entry so
+        downstream tables can report both raw and ceiling-normalized
+        scores.
+    min_ceiling
+        Voxels with ceiling below this threshold are dropped from the
+        normalized mean to avoid division instability.
 
     Returns
     -------
     dict
         ``{roi: {"full_r2": float, "dR2_<m>": float, ...}}``, values
-        are ROI-mean scores.
+        are ROI-mean scores. Adds ``full_r2_normalized`` and
+        ``ceiling_mean`` per ROI when ``ceiling`` is provided.
     """
     out: dict[str, dict[str, float]] = {}
     full = result.full_r2.cpu().numpy()
     dr2 = {m: result.delta_r2[m].cpu().numpy() for m in result.modality_order}
+
+    if ceiling is not None:
+        ceiling = np.asarray(ceiling)
+        if ceiling.shape != full.shape:
+            raise ValueError(
+                f"ceiling shape {ceiling.shape} does not match full_r2 {full.shape}"
+            )
+
     for roi, idx in roi_indices.items():
         row = {"full_r2": float(np.mean(full[idx]))}
         for m in result.modality_order:
             row[f"dR2_{m}"] = float(np.mean(dr2[m][idx]))
+        if ceiling is not None:
+            c_roi = ceiling[idx]
+            mask = c_roi > min_ceiling
+            if mask.any():
+                normalized = full[idx][mask] / c_roi[mask]
+                row["full_r2_normalized"] = float(np.mean(normalized))
+            else:
+                row["full_r2_normalized"] = float("nan")
+            row["ceiling_mean"] = float(np.mean(c_roi))
         out[roi] = row
     return out
 

--- a/src/cortexlab/analysis/lesion.py
+++ b/src/cortexlab/analysis/lesion.py
@@ -66,6 +66,17 @@ class LesionResult:
         Number of held-out test stimuli used to score predictions.
     best_alpha
         Per-voxel selected ridge alpha (diagnostic).
+    p_values
+        When :func:`run_modality_lesion` is called with
+        ``n_permutations > 0``, ``p_values[m]`` is a ``(n_voxels,)``
+        float32 tensor of one-sided p-values for the null that
+        modality ``m``'s test-time features are uninformative
+        (constructed by row-permuting ``X_test[:, slice(m)]``).
+        Smaller values mean the observed ``delta_r2[m]`` is unlikely
+        under the null. ``None`` when no permutation test was run.
+    n_permutations
+        Number of random permutations used; 0 when no permutation test
+        was performed.
     """
 
     full_r2: torch.Tensor
@@ -75,6 +86,8 @@ class LesionResult:
     n_train: int
     n_test: int
     best_alpha: torch.Tensor = field(default_factory=lambda: torch.empty(0))
+    p_values: dict[str, torch.Tensor] | None = None
+    n_permutations: int = 0
 
 
 def run_modality_lesion(
@@ -87,6 +100,8 @@ def run_modality_lesion(
     mask_strategy: MaskStrategy = "zero",
     device: str | None = None,
     backend: str = "auto",
+    n_permutations: int = 0,
+    permutation_seed: int = 0,
 ) -> LesionResult:
     """Run the causal modality lesion protocol.
 
@@ -108,6 +123,17 @@ def run_modality_lesion(
         Torch device for the ridge solve.
     backend
         Ridge backend: ``"torch"``, ``"triton"``, or ``"auto"``.
+    n_permutations
+        If > 0, run a modality-wise label-permutation test against the
+        null that modality ``m``'s test features are uninformative. For
+        each of ``n_permutations`` random permutations, the rows of
+        ``X_test[:, slice(m)]`` are shuffled across stimuli (the encoder
+        is NOT refit) and the resulting ``delta_r2_null`` compared to
+        the observed ``delta_r2``. Per-voxel one-sided p-values
+        (``(count(null >= observed) + 1) / (n_permutations + 1)``) are
+        returned in ``LesionResult.p_values``.
+    permutation_seed
+        RNG seed for reproducible permutations.
 
     Returns
     -------
@@ -180,6 +206,7 @@ def run_modality_lesion(
     # modalities. We keep the original encoder and ask "what if this
     # modality had been absent at inference time?".
     delta: dict[str, torch.Tensor] = {}
+    r2_ablated: dict[str, torch.Tensor] = {}
     for m in modality_order:
         X_test_ablated = X_test.clone()
         sl = slices[m]
@@ -187,11 +214,61 @@ def run_modality_lesion(
         Y_hat_m = enc.predict(X_test_ablated)
         r2_m = _r2_score(Y_test, Y_hat_m)
         delta[m] = r2_full - r2_m
+        r2_ablated[m] = r2_m
         logger.info(
             "  lesion %s: mean dR^2 = %+.4f (top quintile %+.4f)",
             m, delta[m].mean().item(),
             delta[m].quantile(0.8).item(),
         )
+
+    # Optional permutation test: shuffle the test-time stimulus order of
+    # modality m's feature block only (leaving the other modalities' rows
+    # intact) and re-evaluate. Under the null "modality m adds nothing at
+    # test time", delta_null should be distributed around delta_observed;
+    # under the alternative, delta_observed is much larger.
+    p_values: dict[str, torch.Tensor] | None = None
+    if n_permutations > 0:
+        if n_permutations < 0:
+            raise ValueError(f"n_permutations must be >= 0, got {n_permutations}")
+        n_test = X_test.shape[0]
+        n_vox = int(Y_test.shape[1])
+        # Seeded RNG on CPU so permutations are reproducible regardless
+        # of target_device (CUDA randperm with a generator is fiddly).
+        rng = torch.Generator(device="cpu").manual_seed(int(permutation_seed))
+        counts = {
+            m: torch.zeros(n_vox, dtype=torch.int32, device=target_device)
+            for m in modality_order
+        }
+        for b in range(n_permutations):
+            perm = torch.randperm(n_test, generator=rng).to(target_device)
+            for m in modality_order:
+                sl = slices[m]
+                X_perm = X_test.clone()
+                X_perm[:, sl] = X_test[perm][:, sl]
+                Y_hat_null = enc.predict(X_perm)
+                r2_full_null = _r2_score(Y_test, Y_hat_null)
+                # The ablated prediction is invariant under this
+                # row-permutation because the slice is replaced by a
+                # constant mask; reuse the observed r2_ablated[m].
+                delta_null = r2_full_null - r2_ablated[m]
+                counts[m] += (delta_null >= delta[m]).to(torch.int32)
+            if (b + 1) % max(1, n_permutations // 10) == 0:
+                logger.info(
+                    "  permutation %d / %d done",
+                    b + 1, n_permutations,
+                )
+        # "+1" smoothing so p is never exactly zero when none of the
+        # nulls exceeded observed (classic Phipson & Smyth 2010 fix).
+        p_values = {
+            m: (counts[m].to(torch.float32) + 1.0) / (n_permutations + 1.0)
+            for m in modality_order
+        }
+        for m in modality_order:
+            frac_sig = float((p_values[m] < 0.05).float().mean().item())
+            logger.info(
+                "  %s: median p = %.3f, fraction p<0.05 = %.3f",
+                m, float(p_values[m].median().item()), frac_sig,
+            )
 
     return LesionResult(
         full_r2=r2_full,
@@ -201,6 +278,8 @@ def run_modality_lesion(
         n_train=int(Y_train.shape[0]),
         n_test=int(Y_test.shape[0]),
         best_alpha=enc.best_alpha_,
+        p_values=p_values,
+        n_permutations=int(n_permutations),
     )
 
 
@@ -235,11 +314,17 @@ def roi_summary(
     dict
         ``{roi: {"full_r2": float, "dR2_<m>": float, ...}}``, values
         are ROI-mean scores. Adds ``full_r2_normalized`` and
-        ``ceiling_mean`` per ROI when ``ceiling`` is provided.
+        ``ceiling_mean`` per ROI when ``ceiling`` is provided. Adds
+        ``p_<m>_median`` and ``frac_sig_<m>`` (at alpha=0.05) per ROI
+        when ``result.p_values`` is populated by
+        :func:`run_modality_lesion` with ``n_permutations > 0``.
     """
     out: dict[str, dict[str, float]] = {}
     full = result.full_r2.cpu().numpy()
     dr2 = {m: result.delta_r2[m].cpu().numpy() for m in result.modality_order}
+    p_vals: dict[str, np.ndarray] | None = None
+    if result.p_values is not None:
+        p_vals = {m: result.p_values[m].cpu().numpy() for m in result.modality_order}
 
     if ceiling is not None:
         ceiling = np.asarray(ceiling)
@@ -252,6 +337,9 @@ def roi_summary(
         row = {"full_r2": float(np.mean(full[idx]))}
         for m in result.modality_order:
             row[f"dR2_{m}"] = float(np.mean(dr2[m][idx]))
+            if p_vals is not None:
+                row[f"p_{m}_median"] = float(np.median(p_vals[m][idx]))
+                row[f"frac_sig_{m}"] = float(np.mean(p_vals[m][idx] < 0.05))
         if ceiling is not None:
             c_roi = ceiling[idx]
             mask = c_roi > min_ceiling

--- a/src/cortexlab/data/parcellations.py
+++ b/src/cortexlab/data/parcellations.py
@@ -1,0 +1,359 @@
+"""Cortical parcellation loaders for brain-encoding experiments.
+
+A *parcellation* maps each cortical vertex to a named region of interest
+(ROI). Brain-encoding studies typically report per-ROI statistics (mean
+R^2, delta R^2 under lesion, alignment strength) rather than per-vertex
+numbers, because the per-vertex signal is noisy and the neuroscience
+narrative lives at the ROI level (V1, FFA, STG, ATL, etc.).
+
+This module exposes two things:
+
+1. :func:`build_roi_indices` — a pure-data helper that converts the
+   FreeSurfer ``.annot`` format (``labels``, ``names``) into the
+   ``{roi_name: int_array}`` dict that
+   :func:`cortexlab.data.studies.lahner2024bold.load_subject` consumes via
+   its ``parcellation=`` kwarg.
+
+2. :func:`load_hcp_mmp_fsaverage` — a convenience loader for the
+   Glasser et al. 2016 HCP-MMP 1.0 parcellation on the fsaverage7
+   surface. Accepts paths to the left- and right-hemisphere ``.annot``
+   files and returns the combined-hemisphere vertex indices for a
+   user-selected subset of ROIs.
+
+The module is intentionally path-agnostic; it does not download atlas
+files. Users point it at ``.annot`` files they already have locally.
+
+Where to get the HCP-MMP fsaverage annot files
+-----------------------------------------------
+
+The official projections are distributed several ways:
+
+* ``$FREESURFER_HOME/subjects/fsaverage/label/lh.HCPMMP1.annot`` (and
+  ``rh.HCPMMP1.annot``) when using the ``--hcp-mmp`` FreeSurfer build.
+* `github.com/faskowit/multiAtlasTT` (atlases repackaged for multiple
+  subjects including fsaverage).
+* `github.com/HolmesLab/Parcellations_onto_fsaverage`.
+
+Any of these work as long as the resulting file parses with
+``nibabel.freesurfer.io.read_annot``.
+
+Default ROI subset for NeuroAI studies
+---------------------------------------
+
+The default selection in :func:`load_hcp_mmp_fsaverage` covers the
+regions most commonly reported in multimodal brain-encoding papers:
+
+* **Early visual**: V1, V2, V3, V4
+* **Lateral occipital**: LO1, LO2, LO3, MT, MST
+* **Category-selective**: FFC (face complex), PH (place-related)
+* **Auditory**: A1, A4, A5
+* **Superior temporal**: STSda, STSdp, STSva, STSvp
+* **Language**: 44, 45 (Broca), IFJa, IFJp, PFm, PGs, PGi (angular /
+  IPL)
+* **Anterior temporal**: TF, TGd, TGv
+
+Callers can ask for any other HCP-MMP region by name via the ``rois``
+argument.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# default ROI set for NeuroAI lesion studies                                  #
+# --------------------------------------------------------------------------- #
+
+DEFAULT_HCP_MMP_ROIS: tuple[str, ...] = (
+    # Early visual hierarchy.
+    "V1", "V2", "V3", "V4",
+    # Lateral occipital / motion-selective.
+    "LO1", "LO2", "LO3", "MT", "MST",
+    # Category-selective.
+    "FFC", "PH",
+    # Auditory.
+    "A1", "A4", "A5",
+    # Superior temporal sulcus subdivisions.
+    "STSda", "STSdp", "STSva", "STSvp",
+    # Classical language.
+    "44", "45", "IFJa", "IFJp",
+    # Angular gyrus / inferior parietal lobule.
+    "PFm", "PGs", "PGi",
+    # Anterior temporal lobe proxies.
+    "TF", "TGd", "TGv",
+)
+"""HCP-MMP ROI names we report by default. Covers the visual / auditory /
+language / multimodal split that NeuroAI encoding papers typically present.
+"""
+
+
+# The HCP-MMP release prefixes each label with ``L_`` or ``R_`` and suffixes
+# with ``_ROI``. Users can pass either the bare region name ("V1") or the
+# fully-qualified form ("L_V1_ROI"); we normalize internally.
+_HCP_MMP_PREFIX: dict[str, str] = {"left": "L_", "right": "R_"}
+_HCP_MMP_SUFFIX: str = "_ROI"
+
+
+# --------------------------------------------------------------------------- #
+# core helper                                                                 #
+# --------------------------------------------------------------------------- #
+
+def build_roi_indices(
+    labels_lh: np.ndarray,
+    names_lh: Sequence[str],
+    labels_rh: np.ndarray,
+    names_rh: Sequence[str],
+    rois: Sequence[str],
+    strict: bool = False,
+) -> dict[str, np.ndarray]:
+    """Convert annot-style labels + names into combined-hemisphere ROI indices.
+
+    The return format matches what
+    :func:`cortexlab.data.studies.lahner2024bold.load_subject` expects for
+    its ``parcellation`` kwarg: each value is a 1-D ``int64`` array of
+    vertex indices into the concatenated ``(left ‖ right)`` cortex, with
+    the right hemisphere offset by ``len(labels_lh)``.
+
+    Parameters
+    ----------
+    labels_lh, labels_rh
+        Integer label arrays, one entry per vertex, typically 163842 for
+        fsaverage7. Each entry indexes into ``names_lh`` / ``names_rh``.
+    names_lh, names_rh
+        Region names indexed by the label values. Exactly the tuple
+        returned by ``nibabel.freesurfer.io.read_annot`` once names are
+        decoded from bytes to str.
+    rois
+        ROI names to include. Can be either bare ("V1") or
+        hemisphere-qualified ("L_V1_ROI"). Matching is done
+        case-insensitively and tolerates the ``L_...`` / ``R_...`` and
+        ``_ROI`` decorations.
+    strict
+        When True, raise ``KeyError`` if a requested ROI matches neither
+        hemisphere. When False, skip missing ROIs with a warning and
+        return what was found.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        ``{roi_name: int64_indices}``. Region names are returned in the
+        bare form (no ``L_`` / ``R_`` / ``_ROI`` decoration); the indices
+        combine both hemispheres.
+
+    Raises
+    ------
+    ValueError
+        If ``labels_lh`` and ``labels_rh`` have different lengths.
+    KeyError
+        If ``strict=True`` and a requested ROI is not found.
+
+    Examples
+    --------
+    >>> labels_lh = np.array([0, 1, 1, 2])          # 4 vertices, 3 regions
+    >>> names_lh = ["L_???", "L_V1_ROI", "L_V2_ROI"]
+    >>> labels_rh = np.array([0, 2, 1, 1])
+    >>> names_rh = ["R_???", "R_V1_ROI", "R_V2_ROI"]
+    >>> idx = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh,
+    ...                         rois=["V1", "V2"])
+    >>> sorted(idx["V1"].tolist())
+    [1, 2, 6, 7]
+    >>> sorted(idx["V2"].tolist())
+    [3, 5]
+    """
+    labels_lh = np.asarray(labels_lh)
+    labels_rh = np.asarray(labels_rh)
+    if labels_lh.ndim != 1 or labels_rh.ndim != 1:
+        raise ValueError("labels arrays must be 1-D")
+    n_lh = int(labels_lh.shape[0])
+
+    name_to_idx_lh = {_canonical(n): i for i, n in enumerate(names_lh)}
+    name_to_idx_rh = {_canonical(n): i for i, n in enumerate(names_rh)}
+
+    out: dict[str, np.ndarray] = {}
+    for roi in rois:
+        canonical = _canonical(roi)
+        pieces: list[np.ndarray] = []
+        if canonical in name_to_idx_lh:
+            lh_label = name_to_idx_lh[canonical]
+            pieces.append(np.where(labels_lh == lh_label)[0].astype(np.int64))
+        if canonical in name_to_idx_rh:
+            rh_label = name_to_idx_rh[canonical]
+            pieces.append(
+                (np.where(labels_rh == rh_label)[0] + n_lh).astype(np.int64)
+            )
+        if not pieces:
+            msg = f"ROI {roi!r} (canonical {canonical!r}) not found in either hemisphere"
+            if strict:
+                raise KeyError(msg)
+            logger.warning(msg + "; skipping")
+            continue
+        combined = np.concatenate(pieces)
+        if combined.size == 0:
+            logger.warning("ROI %r has zero vertices in the annot; skipping", roi)
+            continue
+        out[_friendly(roi)] = np.sort(combined)
+    return out
+
+
+def _canonical(name: str | bytes) -> str:
+    """Normalize a region name to its bare, case-folded form.
+
+    ``L_V1_ROI``, ``R_V1_ROI``, ``V1``, and ``v1`` all canonicalize to
+    ``"v1"`` so that lookups in either hemisphere match regardless of
+    which convention the caller uses.
+    """
+    if isinstance(name, bytes):
+        name = name.decode("utf-8", errors="replace")
+    s = name.strip()
+    for prefix in _HCP_MMP_PREFIX.values():
+        if s.startswith(prefix):
+            s = s[len(prefix):]
+            break
+    if s.endswith(_HCP_MMP_SUFFIX):
+        s = s[: -len(_HCP_MMP_SUFFIX)]
+    return s.casefold()
+
+
+def _friendly(name: str) -> str:
+    """Return a pretty display name for dict keys (strips ``L_`` / ``_ROI``
+    decoration but preserves the user's original case when unambiguous).
+    """
+    s = name.strip()
+    for prefix in _HCP_MMP_PREFIX.values():
+        if s.startswith(prefix):
+            s = s[len(prefix):]
+            break
+    if s.endswith(_HCP_MMP_SUFFIX):
+        s = s[: -len(_HCP_MMP_SUFFIX)]
+    return s
+
+
+# --------------------------------------------------------------------------- #
+# HCP-MMP 1.0 fsaverage convenience loader                                    #
+# --------------------------------------------------------------------------- #
+
+def load_hcp_mmp_fsaverage(
+    lh_annot_path: str | os.PathLike,
+    rh_annot_path: str | os.PathLike,
+    rois: Sequence[str] | None = None,
+    strict: bool = False,
+) -> dict[str, np.ndarray]:
+    """Load HCP-MMP 1.0 ROIs for fsaverage from FreeSurfer ``.annot`` files.
+
+    Parameters
+    ----------
+    lh_annot_path, rh_annot_path
+        Paths to the left- and right-hemisphere annot files. Typically
+        ``fsaverage/label/lh.HCPMMP1.annot`` and ``rh.HCPMMP1.annot``
+        from a FreeSurfer install, or equivalent downloads (see the
+        module docstring for sources).
+    rois
+        Which HCP-MMP region names to include. None uses
+        :data:`DEFAULT_HCP_MMP_ROIS`. Region names can be given with or
+        without the ``L_`` / ``R_`` prefix and ``_ROI`` suffix.
+    strict
+        Forwarded to :func:`build_roi_indices`.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        Maps each ROI name to its combined-hemisphere vertex indices.
+        Ready to pass as ``parcellation=`` to ``load_subject``.
+
+    Notes
+    -----
+    This function uses ``nibabel.freesurfer.io.read_annot``, which
+    returns the label array, the RGBA color table, and the list of
+    region names. Only the labels and names are used here.
+    """
+    try:
+        import nibabel.freesurfer.io as fsio  # noqa: WPS433  (lazy dep)
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "load_hcp_mmp_fsaverage requires nibabel. Install it with "
+            "`pip install nibabel`, or install the [analysis] extras."
+        ) from e
+
+    lh_path = Path(lh_annot_path)
+    rh_path = Path(rh_annot_path)
+    if not lh_path.exists():
+        raise FileNotFoundError(f"left annot file not found: {lh_path}")
+    if not rh_path.exists():
+        raise FileNotFoundError(f"right annot file not found: {rh_path}")
+
+    labels_lh, _ctab_lh, names_lh_b = fsio.read_annot(str(lh_path))
+    labels_rh, _ctab_rh, names_rh_b = fsio.read_annot(str(rh_path))
+    # nibabel returns bytes in `names` until 5.x; handle both.
+    names_lh = [n.decode("utf-8", errors="replace") if isinstance(n, bytes) else n
+                for n in names_lh_b]
+    names_rh = [n.decode("utf-8", errors="replace") if isinstance(n, bytes) else n
+                for n in names_rh_b]
+
+    target_rois = tuple(rois) if rois is not None else DEFAULT_HCP_MMP_ROIS
+    roi_indices = build_roi_indices(
+        labels_lh, names_lh, labels_rh, names_rh,
+        rois=target_rois, strict=strict,
+    )
+    logger.info(
+        "loaded HCP-MMP fsaverage parcellation: %d ROIs recovered from %s + %s",
+        len(roi_indices), lh_path.name, rh_path.name,
+    )
+    return roi_indices
+
+
+# --------------------------------------------------------------------------- #
+# env-based convenience                                                       #
+# --------------------------------------------------------------------------- #
+
+def load_hcp_mmp_from_freesurfer(
+    subjects_dir: str | os.PathLike | None = None,
+    subject: str = "fsaverage",
+    rois: Sequence[str] | None = None,
+    strict: bool = False,
+) -> dict[str, np.ndarray]:
+    """Load HCP-MMP from a standard FreeSurfer ``SUBJECTS_DIR`` layout.
+
+    Convenience wrapper around :func:`load_hcp_mmp_fsaverage` that looks
+    for ``{subjects_dir}/{subject}/label/{lh,rh}.HCPMMP1.annot``.
+
+    Parameters
+    ----------
+    subjects_dir
+        Path to FreeSurfer's ``SUBJECTS_DIR``. Falls back to the
+        environment variable of the same name when None.
+    subject
+        Subject directory name. ``"fsaverage"`` for the standard
+        template; use a subject ID for per-subject cortical surfaces.
+    rois, strict
+        Forwarded to :func:`load_hcp_mmp_fsaverage`.
+    """
+    if subjects_dir is None:
+        env = os.environ.get("SUBJECTS_DIR")
+        if not env:
+            raise RuntimeError(
+                "subjects_dir not given and SUBJECTS_DIR env var is unset"
+            )
+        subjects_dir = env
+    root = Path(subjects_dir) / subject / "label"
+    return load_hcp_mmp_fsaverage(
+        lh_annot_path=root / "lh.HCPMMP1.annot",
+        rh_annot_path=root / "rh.HCPMMP1.annot",
+        rois=rois,
+        strict=strict,
+    )
+
+
+__all__ = [
+    "DEFAULT_HCP_MMP_ROIS",
+    "build_roi_indices",
+    "load_hcp_mmp_fsaverage",
+    "load_hcp_mmp_from_freesurfer",
+]

--- a/src/cortexlab/data/studies/lahner2024bold.py
+++ b/src/cortexlab/data/studies/lahner2024bold.py
@@ -474,6 +474,132 @@ def load_subject(
     }
 
 
+NOISE_CEILING_FILENAME_TEMPLATE: tp.Final[str] = (
+    "sub-{subject_id:02d}_organized_noiseceiling_task-{split}_hemi-{hemi}_n-{n}.pkl"
+)
+"""Filename convention used by the BOLD Moments authors for pre-computed
+noise ceilings, as shipped under ``prepared_betas/`` alongside the betas.
+Both the ``n-10`` (all subjects) and ``n-k`` (subset) variants follow this
+template."""
+
+
+def load_noise_ceiling(
+    subject_id: int,
+    root: str | os.PathLike | None = None,
+    split: str = "test",
+    n: int = 10,
+) -> np.ndarray:
+    """Load the BOLD Moments on-disk noise ceiling for one subject.
+
+    The Lahner 2024 release ships pre-computed noise ceilings as
+    per-hemisphere pickles alongside the prepared betas. Each pickle holds
+    a 1-D array of length :data:`N_VERTICES_PER_HEMI` (163842) with the
+    per-vertex ceiling in ``R^2`` (squared Pearson correlation) space,
+    computed across ``n`` subjects. The ``n=10`` variant is the default
+    and is what ceiling-normalized model scores should be compared
+    against.
+
+    Parameters
+    ----------
+    subject_id
+        1 through 10. The noise ceiling is per-subject because it uses a
+        leave-one-out construction against the other ``n-1`` subjects'
+        mean response.
+    root
+        Dataset root. Falls back to ``CORTEXLAB_DATA`` when None, same
+        resolution rules as :func:`load_subject`.
+    split
+        ``"train"`` or ``"test"``. Typically ``"test"`` is the only one
+        used in practice, because the 102-clip test split's 10
+        repetitions make the ceiling estimator robust.
+    n
+        The ``n`` suffix in the filename (subjects used to build the
+        ceiling). BOLD Moments ships ``n=10``.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(2 * N_VERTICES_PER_HEMI,)`` = ``(327684,)``, dtype
+        ``float32``. Left hemisphere first, right hemisphere second,
+        matching the vertex layout used by :func:`load_subject`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If either per-hemisphere pickle is missing.
+    ValueError
+        If the loaded array has the wrong shape.
+
+    Notes
+    -----
+    The on-disk ceiling and :func:`cortexlab.analysis.noise_ceiling.inter_subject_ceiling`
+    compute essentially the same quantity. Use the on-disk file when you
+    want the authors' canonical value; use the in-memory helper when you
+    want the ceiling restricted to the subjects you actually loaded.
+    """
+    if split not in ("train", "test"):
+        raise ValueError(f"split must be 'train' or 'test'; got {split!r}")
+
+    root_path = _resolve_root(root)
+    betas_root = root_path / BETAS_SUBPATH / f"sub-{subject_id:02d}" / "prepared_betas"
+    if not betas_root.is_dir():
+        raise FileNotFoundError(
+            f"expected prepared betas under {betas_root}; cannot find noise ceiling."
+        )
+
+    hemi_arrays: list[np.ndarray] = []
+    for hemi in ("left", "right"):
+        fname = NOISE_CEILING_FILENAME_TEMPLATE.format(
+            subject_id=subject_id, split=split, hemi=hemi, n=n,
+        )
+        fp = betas_root / fname
+        if not fp.exists():
+            raise FileNotFoundError(
+                f"missing noise-ceiling file {fp}. "
+                f"Expected the Lahner 2024 convention {NOISE_CEILING_FILENAME_TEMPLATE!r}."
+            )
+        with fp.open("rb") as f:
+            obj = pkl.load(f)
+        arr = _unwrap_ceiling_payload(obj)
+        if arr.shape != (N_VERTICES_PER_HEMI,):
+            raise ValueError(
+                f"{fp.name}: expected ceiling shape ({N_VERTICES_PER_HEMI},), "
+                f"got {arr.shape}"
+            )
+        hemi_arrays.append(arr.astype(np.float32, copy=False))
+
+    ceiling = np.concatenate(hemi_arrays, axis=0)
+    logger.info(
+        "loaded noise ceiling for sub-%02d/%s (n=%d): mean=%.3f, median=%.3f",
+        subject_id, split, n, float(ceiling.mean()), float(np.median(ceiling)),
+    )
+    return ceiling
+
+
+def _unwrap_ceiling_payload(obj: tp.Any) -> np.ndarray:
+    """Coerce a pickled ceiling object to a 1-D numpy array.
+
+    The BOLD Moments release stores the ceiling straight as a numpy array
+    in some distributions and as a single-element tuple in others (the
+    pickled container inherits the author's intermediate processing
+    layout). Accept either and anything that exposes an ``.array``-like
+    view; raise ``TypeError`` otherwise so the user sees a clear message
+    instead of a numpy shape error three layers down.
+    """
+    if isinstance(obj, np.ndarray):
+        arr = obj
+    elif isinstance(obj, (tuple, list)) and obj:
+        arr = np.asarray(obj[0])
+    elif hasattr(obj, "__array__"):
+        arr = np.asarray(obj)
+    else:
+        raise TypeError(
+            f"unexpected noise-ceiling payload type {type(obj).__name__}; "
+            "expected numpy array or tuple whose first element is an array."
+        )
+    return np.squeeze(arr)
+
+
 class Lahner2024Bold(study.Study):
     device: tp.ClassVar[str] = "Fmri"
     dataset_name: tp.ClassVar[str] = "BOLD Moments"

--- a/tests/test_lahner_noise_ceiling.py
+++ b/tests/test_lahner_noise_ceiling.py
@@ -1,0 +1,184 @@
+"""Tests for :func:`cortexlab.data.studies.lahner2024bold.load_noise_ceiling`.
+
+Synthesizes a tiny on-disk mirror of the BOLD Moments
+``prepared_betas/`` layout for one subject, writes per-hemisphere
+ceiling pickles in the author's naming convention, and exercises the
+loader's parsing and error paths without needing the real dataset.
+"""
+
+from __future__ import annotations
+
+import pickle as pkl
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cortexlab.data.studies.lahner2024bold import (
+    BETAS_SUBPATH,
+    NOISE_CEILING_FILENAME_TEMPLATE,
+    load_noise_ceiling,
+)
+
+
+@pytest.fixture
+def tiny_vertices(monkeypatch):
+    """Shrink N_VERTICES_PER_HEMI so tiny synthetic pickles are valid."""
+    monkeypatch.setattr(
+        "cortexlab.data.studies.lahner2024bold.N_VERTICES_PER_HEMI", 16,
+    )
+    return 16
+
+
+def _write_ceiling(
+    root: Path,
+    subject_id: int,
+    split: str,
+    n: int,
+    lh: np.ndarray,
+    rh: np.ndarray,
+    *,
+    payload_wrap: str = "array",
+) -> None:
+    """Write both hemisphere ceiling pickles for one subject.
+
+    ``payload_wrap`` selects how the per-hemisphere array is stored:
+    ``"array"`` plain ndarray, ``"tuple"`` single-element tuple,
+    ``"list"`` single-element list.
+    """
+    sub_dir = root / BETAS_SUBPATH / f"sub-{subject_id:02d}" / "prepared_betas"
+    sub_dir.mkdir(parents=True, exist_ok=True)
+    for hemi, arr in (("left", lh), ("right", rh)):
+        fp = sub_dir / NOISE_CEILING_FILENAME_TEMPLATE.format(
+            subject_id=subject_id, split=split, hemi=hemi, n=n,
+        )
+        if payload_wrap == "array":
+            payload = arr
+        elif payload_wrap == "tuple":
+            payload = (arr,)
+        elif payload_wrap == "list":
+            payload = [arr]
+        else:
+            raise ValueError(payload_wrap)
+        with fp.open("wb") as f:
+            pkl.dump(payload, f)
+
+
+# --------------------------------------------------------------------------- #
+# happy path                                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_load_noise_ceiling_shape_and_dtype(tmp_path, tiny_vertices):
+    lh = np.linspace(0.0, 0.5, tiny_vertices, dtype=np.float32)
+    rh = np.linspace(0.2, 0.8, tiny_vertices, dtype=np.float32)
+    _write_ceiling(tmp_path, subject_id=1, split="test", n=10, lh=lh, rh=rh)
+
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path, split="test", n=10)
+    assert ceiling.shape == (2 * tiny_vertices,)
+    assert ceiling.dtype == np.float32
+    np.testing.assert_allclose(ceiling[:tiny_vertices], lh)
+    np.testing.assert_allclose(ceiling[tiny_vertices:], rh)
+
+
+def test_load_noise_ceiling_accepts_tuple_payload(tmp_path, tiny_vertices):
+    lh = np.random.default_rng(0).random(tiny_vertices).astype(np.float32)
+    rh = np.random.default_rng(1).random(tiny_vertices).astype(np.float32)
+    _write_ceiling(tmp_path, 1, "test", 10, lh, rh, payload_wrap="tuple")
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path)
+    assert ceiling.shape == (2 * tiny_vertices,)
+
+
+def test_load_noise_ceiling_accepts_list_payload(tmp_path, tiny_vertices):
+    lh = np.zeros(tiny_vertices, dtype=np.float32)
+    rh = np.ones(tiny_vertices, dtype=np.float32) * 0.3
+    _write_ceiling(tmp_path, 1, "test", 10, lh, rh, payload_wrap="list")
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path)
+    assert abs(ceiling.mean() - 0.15) < 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# split + n variations                                                        #
+# --------------------------------------------------------------------------- #
+
+def test_load_noise_ceiling_train_split(tmp_path, tiny_vertices):
+    lh = np.full(tiny_vertices, 0.25, dtype=np.float32)
+    rh = np.full(tiny_vertices, 0.35, dtype=np.float32)
+    _write_ceiling(tmp_path, 1, "train", 10, lh, rh)
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path, split="train")
+    assert ceiling.shape == (2 * tiny_vertices,)
+    assert abs(ceiling[:tiny_vertices].mean() - 0.25) < 1e-6
+
+
+def test_load_noise_ceiling_nondefault_n(tmp_path, tiny_vertices):
+    lh = np.full(tiny_vertices, 0.1, dtype=np.float32)
+    rh = np.full(tiny_vertices, 0.1, dtype=np.float32)
+    _write_ceiling(tmp_path, 1, "test", n=5, lh=lh, rh=rh)
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path, n=5)
+    assert ceiling.shape == (2 * tiny_vertices,)
+
+
+# --------------------------------------------------------------------------- #
+# error paths                                                                 #
+# --------------------------------------------------------------------------- #
+
+def test_load_noise_ceiling_rejects_bad_split(tmp_path, tiny_vertices):
+    with pytest.raises(ValueError, match="split must be"):
+        load_noise_ceiling(subject_id=1, root=tmp_path, split="val")
+
+
+def test_load_noise_ceiling_missing_betas_dir(tmp_path, tiny_vertices):
+    with pytest.raises(FileNotFoundError, match="prepared betas"):
+        load_noise_ceiling(subject_id=1, root=tmp_path)
+
+
+def test_load_noise_ceiling_missing_hemisphere_file(tmp_path, tiny_vertices):
+    lh = np.zeros(tiny_vertices, dtype=np.float32)
+    rh = np.zeros(tiny_vertices, dtype=np.float32)
+    _write_ceiling(tmp_path, 1, "test", 10, lh, rh)
+    # Remove the right-hemisphere file to simulate an incomplete staging.
+    fp_rh = (
+        tmp_path / BETAS_SUBPATH / "sub-01" / "prepared_betas"
+        / NOISE_CEILING_FILENAME_TEMPLATE.format(
+            subject_id=1, split="test", hemi="right", n=10,
+        )
+    )
+    fp_rh.unlink()
+    with pytest.raises(FileNotFoundError, match="noise-ceiling"):
+        load_noise_ceiling(subject_id=1, root=tmp_path)
+
+
+def test_load_noise_ceiling_wrong_shape_raises(tmp_path, tiny_vertices):
+    lh = np.zeros(tiny_vertices + 3, dtype=np.float32)   # wrong length
+    rh = np.zeros(tiny_vertices, dtype=np.float32)
+    _write_ceiling(tmp_path, 1, "test", 10, lh, rh)
+    with pytest.raises(ValueError, match="expected ceiling shape"):
+        load_noise_ceiling(subject_id=1, root=tmp_path)
+
+
+def test_load_noise_ceiling_unknown_payload_type(tmp_path, tiny_vertices):
+    sub_dir = tmp_path / BETAS_SUBPATH / "sub-01" / "prepared_betas"
+    sub_dir.mkdir(parents=True, exist_ok=True)
+    for hemi in ("left", "right"):
+        fp = sub_dir / NOISE_CEILING_FILENAME_TEMPLATE.format(
+            subject_id=1, split="test", hemi=hemi, n=10,
+        )
+        with fp.open("wb") as f:
+            pkl.dump({"oops": "dict"}, f)     # neither array nor tuple
+    with pytest.raises(TypeError, match="unexpected noise-ceiling payload"):
+        load_noise_ceiling(subject_id=1, root=tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# integration: the array is usable by roi_summary                             #
+# --------------------------------------------------------------------------- #
+
+def test_loaded_ceiling_feeds_roi_summary_shape(tmp_path, tiny_vertices):
+    """Sanity: the output is a flat 1-D array of the right length so
+    downstream ``roi_summary(..., ceiling=...)`` calls won't shape-check-fail.
+    """
+    lh = np.full(tiny_vertices, 0.4, dtype=np.float32)
+    rh = np.full(tiny_vertices, 0.6, dtype=np.float32)
+    _write_ceiling(tmp_path, 1, "test", 10, lh, rh)
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path)
+    assert ceiling.ndim == 1
+    assert ceiling.size == 2 * tiny_vertices

--- a/tests/test_lesion.py
+++ b/tests/test_lesion.py
@@ -109,6 +109,52 @@ def test_lesion_rejects_single_modality():
                             np.zeros((5, 3), dtype=np.float32))
 
 
+def test_roi_summary_with_ceiling_adds_normalized_column():
+    """Ceiling-aware roi_summary should report both raw and normalized
+    per-ROI R^2, and should skip voxels whose ceiling falls below
+    ``min_ceiling``.
+    """
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(train, test, y_tr, y_te,
+                                 alphas=[1.0], cv=2, mask_strategy="zero")
+    rois = {"text_roi": np.array([0, 1, 2, 3])}
+    # Build a ceiling of the right length where two voxels are well below
+    # the threshold; the other two sit at 0.5 so normalized = full_r2 / 0.5.
+    n_vox = result.full_r2.shape[0]
+    ceiling = np.full(n_vox, 0.5, dtype=np.float32)
+    ceiling[0] = 0.0         # dropped
+    ceiling[1] = 0.001       # below min_ceiling
+    summary = roi_summary(result, rois, ceiling=ceiling)
+
+    assert "full_r2_normalized" in summary["text_roi"]
+    assert "ceiling_mean" in summary["text_roi"]
+    # Normalized average should only average across voxels 2 and 3.
+    full = result.full_r2.cpu().numpy()
+    expected = float((full[2:4] / 0.5).mean())
+    assert abs(summary["text_roi"]["full_r2_normalized"] - expected) < 1e-6
+
+
+def test_roi_summary_rejects_mismatched_ceiling_shape():
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(train, test, y_tr, y_te,
+                                 alphas=[1.0], cv=2, mask_strategy="zero")
+    bad_ceiling = np.zeros(result.full_r2.shape[0] + 5, dtype=np.float32)
+    with pytest.raises(ValueError, match="shape"):
+        roi_summary(result, {"x": np.array([0])}, ceiling=bad_ceiling)
+
+
+def test_roi_summary_without_ceiling_unchanged():
+    """Backward compat: calls without ceiling return the pre-existing schema."""
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(train, test, y_tr, y_te,
+                                 alphas=[1.0], cv=2, mask_strategy="zero")
+    summary = roi_summary(result, {"text_roi": np.array([0, 1])})
+    row = summary["text_roi"]
+    assert "full_r2_normalized" not in row
+    assert "ceiling_mean" not in row
+    assert "full_r2" in row
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_lesion_handles_cuda_device_end_to_end():
     """Regression test: y_test arrives on CPU, encoder moves inputs to

--- a/tests/test_lesion.py
+++ b/tests/test_lesion.py
@@ -155,6 +155,135 @@ def test_roi_summary_without_ceiling_unchanged():
     assert "full_r2" in row
 
 
+# --------------------------------------------------------------------------- #
+# permutation test                                                            #
+# --------------------------------------------------------------------------- #
+
+def test_permutation_test_produces_small_p_for_true_signal():
+    """When a modality genuinely drives voxels, permuting its test-time
+    rows should make those voxels' delta_R^2 shrink, so the observed
+    delta should sit near the top of the null distribution and the
+    corresponding p-values should be small."""
+    train, test, y_tr, y_te, assignments = _synth_multimodal(noise=0.05)
+    result = run_modality_lesion(
+        train, test, y_tr, y_te,
+        alphas=[1e-2, 1.0, 1e2], cv=3, mask_strategy="zero",
+        n_permutations=200, permutation_seed=0,
+    )
+    assert result.p_values is not None
+    assert result.n_permutations == 200
+    # For each modality's true voxels, at least most should be significant.
+    for m, sl in assignments.items():
+        p_m = result.p_values[m][sl.start:sl.stop].cpu().numpy()
+        frac_sig = (p_m < 0.05).mean()
+        assert frac_sig > 0.5, (
+            f"modality {m}: expected most true voxels significant, "
+            f"got frac_sig={frac_sig:.2f}, p={p_m}"
+        )
+
+
+def test_permutation_test_large_p_for_noise_voxels():
+    """Voxels that don't depend on modality m should have p-values that
+    are NOT uniformly tiny. We allow some leakage through ridge
+    regularization but demand it doesn't look like a clean signal."""
+    train, test, y_tr, y_te, assignments = _synth_multimodal(noise=0.05)
+    result = run_modality_lesion(
+        train, test, y_tr, y_te,
+        alphas=[1.0], cv=2, mask_strategy="zero",
+        n_permutations=200, permutation_seed=1,
+    )
+    text_sl = assignments["text"]
+    for m in ("audio", "video"):
+        p_m = result.p_values[m][text_sl.start:text_sl.stop].cpu().numpy()
+        frac_sig = (p_m < 0.05).mean()
+        assert frac_sig <= 0.5, (
+            f"null-modality {m} on text voxels: too many false positives "
+            f"(frac_sig={frac_sig:.2f})"
+        )
+
+
+def test_permutation_test_zero_permutations_keeps_p_none():
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(
+        train, test, y_tr, y_te,
+        alphas=[1.0], cv=2, mask_strategy="zero",
+        n_permutations=0,
+    )
+    assert result.p_values is None
+    assert result.n_permutations == 0
+
+
+def test_permutation_test_reproducible_with_seed():
+    """Same seed => identical p-values; different seed => different."""
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    kwargs = dict(
+        alphas=[1.0], cv=2, mask_strategy="zero",
+        n_permutations=50,
+    )
+    a = run_modality_lesion(train, test, y_tr, y_te,
+                            permutation_seed=7, **kwargs)
+    b = run_modality_lesion(train, test, y_tr, y_te,
+                            permutation_seed=7, **kwargs)
+    c = run_modality_lesion(train, test, y_tr, y_te,
+                            permutation_seed=13, **kwargs)
+    for m in a.modality_order:
+        assert torch.equal(a.p_values[m], b.p_values[m]), f"seed reproducibility broken for {m}"
+        assert not torch.equal(a.p_values[m], c.p_values[m])
+
+
+def test_permutation_p_values_respect_one_sided_bounds():
+    """All p-values live in [1/(B+1), 1] because of the Phipson-Smyth +1 smoothing."""
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(
+        train, test, y_tr, y_te,
+        alphas=[1.0], cv=2, mask_strategy="zero",
+        n_permutations=10, permutation_seed=0,
+    )
+    expected_floor = 1.0 / (10 + 1)
+    for m in result.modality_order:
+        p = result.p_values[m]
+        assert (p >= expected_floor - 1e-6).all()
+        assert (p <= 1.0 + 1e-6).all()
+
+
+def test_roi_summary_exposes_permutation_columns():
+    """roi_summary should surface p-value aggregates per ROI when the
+    LesionResult has populated p_values."""
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(
+        train, test, y_tr, y_te,
+        alphas=[1.0], cv=2, mask_strategy="zero",
+        n_permutations=50, permutation_seed=0,
+    )
+    rois = {
+        "text_roi":  np.array([0, 1, 2, 3]),
+        "audio_roi": np.array([4, 5, 6, 7]),
+        "video_roi": np.array([8, 9, 10, 11]),
+    }
+    summary = roi_summary(result, rois)
+    for roi_name in rois:
+        row = summary[roi_name]
+        for m in result.modality_order:
+            assert f"p_{m}_median" in row
+            assert f"frac_sig_{m}" in row
+            assert 0.0 <= row[f"p_{m}_median"] <= 1.0
+            assert 0.0 <= row[f"frac_sig_{m}"] <= 1.0
+    # The "own" modality should be at least as significant as the non-owner ones.
+    assert summary["text_roi"]["p_text_median"] <= summary["text_roi"]["p_audio_median"]
+    assert summary["audio_roi"]["p_audio_median"] <= summary["audio_roi"]["p_video_median"]
+
+
+def test_roi_summary_without_permutations_omits_p_columns():
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(train, test, y_tr, y_te,
+                                 alphas=[1.0], cv=2, mask_strategy="zero")
+    summary = roi_summary(result, {"text_roi": np.array([0, 1, 2, 3])})
+    row = summary["text_roi"]
+    for m in result.modality_order:
+        assert f"p_{m}_median" not in row
+        assert f"frac_sig_{m}" not in row
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_lesion_handles_cuda_device_end_to_end():
     """Regression test: y_test arrives on CPU, encoder moves inputs to

--- a/tests/test_parcellations.py
+++ b/tests/test_parcellations.py
@@ -1,0 +1,381 @@
+"""Tests for :mod:`cortexlab.data.parcellations`.
+
+Synthetic annot-style arrays cover every branch of ``build_roi_indices``
+and the HCP-MMP convenience loaders. No on-disk atlas required.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from cortexlab.data.parcellations import (
+    DEFAULT_HCP_MMP_ROIS,
+    build_roi_indices,
+    load_hcp_mmp_fsaverage,
+    load_hcp_mmp_from_freesurfer,
+)
+from cortexlab.data import parcellations as pmod
+
+
+# --------------------------------------------------------------------------- #
+# default ROI set                                                             #
+# --------------------------------------------------------------------------- #
+
+def test_default_roi_set_covers_pillars():
+    """The default set should include at least one ROI from each of the
+    visual / auditory / language pillars a NeuroAI paper needs."""
+    s = set(DEFAULT_HCP_MMP_ROIS)
+    assert {"V1", "V2", "V4"} <= s            # early visual
+    assert {"MT", "MST"} <= s                  # motion
+    assert {"FFC"} <= s                        # face complex
+    assert {"A1"} <= s                         # auditory
+    assert {"44", "45"} <= s                   # Broca
+    assert {"PGs", "PGi"} <= s                 # angular gyrus
+
+
+def test_default_roi_set_has_no_duplicates():
+    assert len(DEFAULT_HCP_MMP_ROIS) == len(set(DEFAULT_HCP_MMP_ROIS))
+
+
+# --------------------------------------------------------------------------- #
+# build_roi_indices — happy paths                                             #
+# --------------------------------------------------------------------------- #
+
+def _fake_lh_rh():
+    """A minimal synthetic bihemispheric annot.
+
+    Left hemisphere has 4 vertices labeled [0, 1, 1, 2].
+    Right hemisphere has 4 vertices labeled [0, 2, 1, 1].
+
+    Region 0 is the unknown/???
+    Region 1 is V1
+    Region 2 is V2
+    """
+    labels_lh = np.array([0, 1, 1, 2], dtype=np.int32)
+    names_lh = ["L_???", "L_V1_ROI", "L_V2_ROI"]
+    labels_rh = np.array([0, 2, 1, 1], dtype=np.int32)
+    names_rh = ["R_???", "R_V1_ROI", "R_V2_ROI"]
+    return labels_lh, names_lh, labels_rh, names_rh
+
+
+def test_build_roi_indices_happy_path():
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(
+        labels_lh, names_lh, labels_rh, names_rh,
+        rois=["V1", "V2"],
+    )
+    # V1 is label 1 in LH (vertices 1, 2) and label 1 in RH (vertices 2, 3).
+    # Right hemisphere indices are offset by n_lh = 4.
+    assert sorted(out["V1"].tolist()) == [1, 2, 6, 7]
+    # V2 is label 2 in LH (vertex 3) and label 2 in RH (vertex 1).
+    assert sorted(out["V2"].tolist()) == [3, 5]
+
+
+def test_build_roi_indices_dtype_is_int64():
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    assert out["V1"].dtype == np.int64
+
+
+def test_build_roi_indices_is_sorted():
+    """Indices should be sorted so downstream slicing has no surprises."""
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    arr = out["V1"]
+    assert np.all(arr[:-1] <= arr[1:])
+
+
+def test_build_roi_indices_right_offset_correct():
+    """Right hemisphere vertex K must land at index K + n_lh in the output."""
+    # LH has 10 vertices, all background.
+    labels_lh = np.zeros(10, dtype=np.int32)
+    names_lh = ["L_???", "L_V1_ROI"]
+    # RH has 4 vertices, last one is V1.
+    labels_rh = np.array([0, 0, 0, 1], dtype=np.int32)
+    names_rh = ["R_???", "R_V1_ROI"]
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    assert out["V1"].tolist() == [13]      # 10 + 3
+
+
+# --------------------------------------------------------------------------- #
+# name normalization: prefix / suffix / case                                  #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("roi_name", ["V1", "v1", "L_V1_ROI", "R_V1_ROI", " V1 "])
+def test_build_roi_indices_matches_regardless_of_decoration(roi_name):
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(
+        labels_lh, names_lh, labels_rh, names_rh, rois=[roi_name],
+    )
+    # Should match V1 in both hemispheres regardless of how the caller spelled it.
+    assert len(out) == 1
+    only_key = next(iter(out))
+    assert sorted(out[only_key].tolist()) == [1, 2, 6, 7]
+
+
+def test_build_roi_indices_tolerates_bytes_names():
+    """nibabel < 5 returns bytes; build_roi_indices should not care."""
+    labels_lh = np.array([0, 1], dtype=np.int32)
+    names_lh = [b"L_???", b"L_V1_ROI"]
+    labels_rh = np.array([0, 1], dtype=np.int32)
+    names_rh = [b"R_???", b"R_V1_ROI"]
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    assert out["V1"].tolist() == [1, 3]    # LH vertex 1, RH vertex 1 + n_lh(2)
+
+
+# --------------------------------------------------------------------------- #
+# missing / zero-vertex ROIs                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_build_roi_indices_missing_strict_raises():
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    with pytest.raises(KeyError, match="not found"):
+        build_roi_indices(
+            labels_lh, names_lh, labels_rh, names_rh,
+            rois=["V1", "FFC"], strict=True,
+        )
+
+
+def test_build_roi_indices_missing_non_strict_skips_and_warns(caplog):
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    with caplog.at_level(logging.WARNING, logger="cortexlab.data.parcellations"):
+        out = build_roi_indices(
+            labels_lh, names_lh, labels_rh, names_rh,
+            rois=["V1", "FFC"], strict=False,
+        )
+    assert "V1" in out
+    assert "FFC" not in out
+    assert any("FFC" in r.message for r in caplog.records)
+
+
+def test_build_roi_indices_one_hemisphere_only_is_fine():
+    """If an ROI exists only in LH (unusual but possible), the returned
+    indices cover just that hemisphere."""
+    labels_lh = np.array([0, 1, 1], dtype=np.int32)
+    names_lh = ["L_???", "L_V1_ROI"]
+    labels_rh = np.array([0, 0], dtype=np.int32)
+    names_rh = ["R_???"]
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    assert out["V1"].tolist() == [1, 2]
+
+
+def test_build_roi_indices_zero_vertex_roi_is_skipped(caplog):
+    """A region name that's listed but has no vertices labeled with it
+    should be skipped rather than returning an empty array (downstream
+    code treats zero-size arrays as errors)."""
+    labels_lh = np.array([0, 0, 0], dtype=np.int32)
+    names_lh = ["L_???", "L_V1_ROI"]   # V1 declared but never labeled
+    labels_rh = np.array([0, 0, 0], dtype=np.int32)
+    names_rh = ["R_???", "R_V1_ROI"]
+    with caplog.at_level(logging.WARNING, logger="cortexlab.data.parcellations"):
+        out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=["V1"])
+    assert "V1" not in out
+    assert any("zero vertices" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# shape / input validation                                                    #
+# --------------------------------------------------------------------------- #
+
+def test_build_roi_indices_rejects_2d_labels():
+    labels_lh = np.zeros((3, 3), dtype=np.int32)
+    with pytest.raises(ValueError, match="1-D"):
+        build_roi_indices(
+            labels_lh, ["L_???"], np.zeros(3, dtype=np.int32), ["R_???"],
+            rois=["V1"],
+        )
+
+
+def test_build_roi_indices_empty_rois_returns_empty_dict():
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(labels_lh, names_lh, labels_rh, names_rh, rois=[])
+    assert out == {}
+
+
+# --------------------------------------------------------------------------- #
+# integration with load_subject's contract                                    #
+# --------------------------------------------------------------------------- #
+
+def test_result_is_loadable_as_parcellation_kwarg():
+    """The dict shape must be {str: int64 ndarray} so load_subject accepts it."""
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    out = build_roi_indices(
+        labels_lh, names_lh, labels_rh, names_rh, rois=["V1", "V2"],
+    )
+    assert isinstance(out, dict)
+    for key, val in out.items():
+        assert isinstance(key, str)
+        assert isinstance(val, np.ndarray)
+        assert val.dtype == np.int64
+        assert val.ndim == 1
+
+
+# --------------------------------------------------------------------------- #
+# load_hcp_mmp_fsaverage (monkeypatched read_annot)                           #
+# --------------------------------------------------------------------------- #
+
+def _install_fake_nibabel(monkeypatch, annots: dict[Path, tuple]):
+    """Install a fake nibabel.freesurfer.io.read_annot that returns the
+    annot tuple for whichever path the caller gives."""
+    calls: list[str] = []
+
+    def fake_read_annot(path: str):
+        calls.append(path)
+        return annots[Path(path)]
+
+    fake_fsio = SimpleNamespace(read_annot=fake_read_annot)
+    fake_freesurfer = SimpleNamespace(io=fake_fsio)
+    fake_nibabel = SimpleNamespace(freesurfer=fake_freesurfer)
+
+    monkeypatch.setitem(sys.modules, "nibabel", fake_nibabel)
+    monkeypatch.setitem(sys.modules, "nibabel.freesurfer", fake_freesurfer)
+    monkeypatch.setitem(sys.modules, "nibabel.freesurfer.io", fake_fsio)
+    return calls
+
+
+def test_load_hcp_mmp_fsaverage_happy(tmp_path, monkeypatch):
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    lh_path = tmp_path / "lh.HCPMMP1.annot"
+    rh_path = tmp_path / "rh.HCPMMP1.annot"
+    lh_path.write_bytes(b"")
+    rh_path.write_bytes(b"")
+
+    ctab = np.zeros((3, 5), dtype=np.int32)
+    annots = {
+        lh_path: (labels_lh, ctab, [n.encode() for n in names_lh]),
+        rh_path: (labels_rh, ctab, [n.encode() for n in names_rh]),
+    }
+    _install_fake_nibabel(monkeypatch, annots)
+
+    out = load_hcp_mmp_fsaverage(lh_path, rh_path, rois=["V1", "V2"])
+    assert set(out.keys()) == {"V1", "V2"}
+    assert sorted(out["V1"].tolist()) == [1, 2, 6, 7]
+
+
+def test_load_hcp_mmp_fsaverage_missing_lh_raises(tmp_path, monkeypatch):
+    rh_path = tmp_path / "rh.HCPMMP1.annot"
+    rh_path.write_bytes(b"")
+    _install_fake_nibabel(monkeypatch, {})
+    with pytest.raises(FileNotFoundError, match="left"):
+        load_hcp_mmp_fsaverage(tmp_path / "missing.annot", rh_path)
+
+
+def test_load_hcp_mmp_fsaverage_missing_rh_raises(tmp_path, monkeypatch):
+    lh_path = tmp_path / "lh.HCPMMP1.annot"
+    lh_path.write_bytes(b"")
+    _install_fake_nibabel(monkeypatch, {})
+    with pytest.raises(FileNotFoundError, match="right"):
+        load_hcp_mmp_fsaverage(lh_path, tmp_path / "missing.annot")
+
+
+def test_load_hcp_mmp_fsaverage_default_rois(tmp_path, monkeypatch):
+    """When rois=None, the loader tries every DEFAULT_HCP_MMP_ROIS name.
+    Absent regions are skipped (non-strict)."""
+    # Build a minimal annot that contains V1 only.
+    labels_lh = np.array([0, 1], dtype=np.int32)
+    names_lh = ["L_???", "L_V1_ROI"]
+    labels_rh = np.array([0, 1], dtype=np.int32)
+    names_rh = ["R_???", "R_V1_ROI"]
+
+    lh_path = tmp_path / "lh.HCPMMP1.annot"
+    rh_path = tmp_path / "rh.HCPMMP1.annot"
+    lh_path.write_bytes(b"")
+    rh_path.write_bytes(b"")
+
+    ctab = np.zeros((2, 5), dtype=np.int32)
+    annots = {
+        lh_path: (labels_lh, ctab, [n.encode() for n in names_lh]),
+        rh_path: (labels_rh, ctab, [n.encode() for n in names_rh]),
+    }
+    _install_fake_nibabel(monkeypatch, annots)
+
+    out = load_hcp_mmp_fsaverage(lh_path, rh_path)      # rois=None
+    assert "V1" in out
+    # Everything else in DEFAULT_HCP_MMP_ROIS is absent in our tiny annot.
+    assert set(out.keys()) == {"V1"}
+
+
+# --------------------------------------------------------------------------- #
+# load_hcp_mmp_from_freesurfer (SUBJECTS_DIR)                                 #
+# --------------------------------------------------------------------------- #
+
+def test_load_hcp_mmp_from_freesurfer_uses_subjects_dir(tmp_path, monkeypatch):
+    subj_root = tmp_path / "subjects" / "fsaverage" / "label"
+    subj_root.mkdir(parents=True)
+    lh_path = subj_root / "lh.HCPMMP1.annot"
+    rh_path = subj_root / "rh.HCPMMP1.annot"
+    lh_path.write_bytes(b"")
+    rh_path.write_bytes(b"")
+
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    ctab = np.zeros((3, 5), dtype=np.int32)
+    annots = {
+        lh_path: (labels_lh, ctab, [n.encode() for n in names_lh]),
+        rh_path: (labels_rh, ctab, [n.encode() for n in names_rh]),
+    }
+    _install_fake_nibabel(monkeypatch, annots)
+
+    out = load_hcp_mmp_from_freesurfer(
+        subjects_dir=tmp_path / "subjects", rois=["V1"],
+    )
+    assert "V1" in out
+
+
+def test_load_hcp_mmp_from_freesurfer_falls_back_to_env(tmp_path, monkeypatch):
+    subj_root = tmp_path / "subjects" / "fsaverage" / "label"
+    subj_root.mkdir(parents=True)
+    lh_path = subj_root / "lh.HCPMMP1.annot"
+    rh_path = subj_root / "rh.HCPMMP1.annot"
+    lh_path.write_bytes(b"")
+    rh_path.write_bytes(b"")
+
+    labels_lh, names_lh, labels_rh, names_rh = _fake_lh_rh()
+    ctab = np.zeros((3, 5), dtype=np.int32)
+    annots = {
+        lh_path: (labels_lh, ctab, [n.encode() for n in names_lh]),
+        rh_path: (labels_rh, ctab, [n.encode() for n in names_rh]),
+    }
+    _install_fake_nibabel(monkeypatch, annots)
+
+    monkeypatch.setenv("SUBJECTS_DIR", str(tmp_path / "subjects"))
+    out = load_hcp_mmp_from_freesurfer(rois=["V1"])
+    assert "V1" in out
+
+
+def test_load_hcp_mmp_from_freesurfer_no_env_raises(monkeypatch):
+    monkeypatch.delenv("SUBJECTS_DIR", raising=False)
+    with pytest.raises(RuntimeError, match="SUBJECTS_DIR"):
+        load_hcp_mmp_from_freesurfer()
+
+
+# --------------------------------------------------------------------------- #
+# internal helpers (exercised indirectly above, but pinning behavior)         #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("name,expected", [
+    ("V1", "v1"),
+    ("L_V1_ROI", "v1"),
+    ("R_V1_ROI", "v1"),
+    ("  v1  ", "v1"),
+    ("L_FFC_ROI", "ffc"),
+    ("44", "44"),
+    (b"L_V1_ROI", "v1"),
+])
+def test_canonical_normalizes(name, expected):
+    assert pmod._canonical(name) == expected
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("V1", "V1"),
+    ("L_V1_ROI", "V1"),
+    ("R_FFC_ROI", "FFC"),
+    ("44", "44"),
+])
+def test_friendly_strips_decoration_preserves_case(name, expected):
+    assert pmod._friendly(name) == expected


### PR DESCRIPTION
Stacked on #47 (noise-ceiling), which is stacked on #46 (parcellation). Base will retarget to \`master\` once the earlier PRs land.

## Summary

Adds significance testing to the lesion protocol so per-ROI tables can answer the first question any brain-encoding reviewer asks: "is this region's modality preference distinguishable from zero?"

- \`run_modality_lesion\` grows \`n_permutations\` and \`permutation_seed\` kwargs. When \`n_permutations > 0\`, the function shuffles rows of \`X_test[:, slice(m)]\` across test stimuli for each modality \`m\`, re-predicts with the fixed encoder (no refit), and compares the resulting \`delta_R^2_null\` to the observed \`delta_R^2\`. Per-voxel one-sided p-values use the Phipson & Smyth (2010) \`+1\` smoothing convention so no p is ever exactly zero, and they live in \`LesionResult.p_values[m]\` next to \`delta_r2[m]\`.
- \`LesionResult\` gains \`p_values: dict[str, Tensor] | None\` and \`n_permutations: int\` fields. \`None\` preserves the pre-existing schema when permutations are skipped.
- \`roi_summary\` surfaces two new columns per modality when p-values are present: \`p_<m>_median\` and \`frac_sig_<m>\` (at alpha=0.05). The columns are absent (not NaN) when no permutation test was run, so downstream tables don't need to feature-flag around the new option.
- \`experiments/causal_modality_ablation.py\` gains \`--permutations\` and \`--permutation-seed\` flags. Per-subject p-value arrays land in the existing \`subject_XX_lesion.npz\` under \`p_<m>\` keys, and the top-level summary picks up \`n_permutations\`, \`p_value_medians\`, and \`frac_sig_at_05\` per modality.

## Why row-permute only the target modality's slice?

Permuting \`Y_test\` wholesale tests a weaker null (\"nothing in the model predicts anything\"). We want the per-modality null (\"modality m specifically is uninformative at test time\") so the test isolates each modality's contribution to \`delta_R^2\`. This matches the standard construction in Lahner 2024 and Conwell 2022.

## Test plan

- [x] \`python -m pytest tests/test_lesion.py -v\` -> 15 passed, 1 skipped (CUDA)
- [x] \`python -m pytest tests/ -q\` -> 238 passed, 3 skipped (no regressions)
- [x] 7 new tests: true-signal voxels yield small p (>50% significant), non-driving modalities don't inflate FP rate on noise voxels, \`n_permutations=0\` keeps \`p_values=None\`, permutation seed is reproducible (same seed -> same output, different seed -> different), p-values respect the \`[1/(B+1), 1]\` floor/ceiling, \`roi_summary\` adds/omits \`p_<m>_median\` correctly
- [x] End-to-end \`--mock\` run with \`--permutations 20\` logs median p per modality and writes per-subject \`p_<m>\` arrays to the npz
- [ ] Real run on Jarvis with \`--permutations 1000\` on one subject + one modality to budget wall-time before fanning out

## Impact on Draft 3 / paper

Any ROI row that now has \`p_<m>_median < 0.05\` is publishable as a causally-significant modality dependency with a permutation-test justification. Previously only effect sizes could be reported. Slot this directly into the Draft 3 lesion table.