### PR TITLE
feat(analysis): noise-ceiling normalization path

### DIFF
--- a/experiments/causal_modality_ablation.py
+++ b/experiments/causal_modality_ablation.py
@@ -41,6 +41,7 @@ import argparse
 import json
 import logging
 import time
+from collections.abc import Mapping
 from dataclasses import asdict
 from pathlib import Path
 
@@ -101,6 +102,18 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--parcellation-rois", type=str, default=None,
                     help="Comma-separated ROI names to include. None uses the "
                          "DEFAULT_HCP_MMP_ROIS set from cortexlab.data.parcellations.")
+    ap.add_argument("--noise-ceiling", type=str, default="none",
+                    choices=["none", "bold-moments", "inter-subject"],
+                    help="Source of per-voxel noise ceiling used to report "
+                         "normalized R^2. 'bold-moments' loads the authors' "
+                         "pre-computed per-subject n-10 ceiling. 'inter-subject' "
+                         "computes the leave-one-subject-out ceiling from the "
+                         "loaded subjects (requires >=2). 'none' skips.")
+    ap.add_argument("--noise-ceiling-n", type=int, default=10,
+                    help="The 'n' suffix of the BOLD Moments ceiling pickle.")
+    ap.add_argument("--noise-ceiling-split", type=str, default="test",
+                    choices=["train", "test"],
+                    help="Which split's on-disk ceiling to load from BOLD Moments.")
     return ap.parse_args()
 
 
@@ -223,8 +236,15 @@ def run_one_subject(
     mask: str,
     device: str,
     backend: str,
+    ceiling: np.ndarray | None = None,
 ) -> dict:
-    """Fit encoder, run lesion, summarize over ROIs."""
+    """Fit encoder, run lesion, summarize over ROIs.
+
+    When ``ceiling`` is provided it is a per-voxel R^2 ceiling aligned
+    with ``rec["y_test"]``'s voxel axis; it flows into
+    :func:`roi_summary` so each ROI row gains a ``full_r2_normalized``
+    column and the top-level summary gains a ``full_r2_normalized_mean``.
+    """
     t0 = time.perf_counter()
     result = run_modality_lesion(
         rec["features_train"], rec["features_test"],
@@ -235,8 +255,8 @@ def run_one_subject(
     elapsed = time.perf_counter() - t0
     logger.info("subject %s: lesion done in %.1fs", rec["subject_id"], elapsed)
 
-    summary = roi_summary(result, rec["roi_indices"])
-    return {
+    summary = roi_summary(result, rec["roi_indices"], ceiling=ceiling)
+    payload = {
         "subject_id": rec["subject_id"],
         "elapsed_sec": elapsed,
         "n_train": result.n_train,
@@ -250,7 +270,18 @@ def run_one_subject(
             for m in result.modality_order
         },
         "modality_order": result.modality_order,
-    }, result
+    }
+    if ceiling is not None:
+        full_np = result.full_r2.cpu().numpy()
+        mask_vox = ceiling > 0.01
+        if mask_vox.any():
+            payload["full_r2_normalized_mean"] = float(
+                (full_np[mask_vox] / ceiling[mask_vox]).mean()
+            )
+        else:
+            payload["full_r2_normalized_mean"] = float("nan")
+        payload["ceiling_mean"] = float(ceiling.mean())
+    return payload, result
 
 
 def run_study(
@@ -269,6 +300,7 @@ def run_study(
     output_dir.mkdir(parents=True, exist_ok=True)
     per_subject = []
     lesion_objs: dict[int, LesionResult] = {}
+    roi_by_subject: dict[int, Mapping[str, np.ndarray]] = {}
     responses_for_ceiling = []
 
     # Parcellation is shared across subjects; load once. Mock mode keeps
@@ -276,6 +308,21 @@ def run_study(
     parcellation = None if mock else _resolve_parcellation(cfg)
     if parcellation is not None:
         logger.info("parcellation loaded: %d ROIs", len(parcellation))
+
+    # Pre-load per-subject on-disk ceilings when requested. For the
+    # inter-subject ceiling we have to wait until all responses are in
+    # memory; it is applied in a post-processing pass below.
+    ceiling_source = (cfg.get("noise_ceiling") or "none") if not mock else "none"
+    ondisk_ceilings: dict[int, np.ndarray] = {}
+    if ceiling_source == "bold-moments" and not mock:
+        from cortexlab.data.studies.lahner2024bold import load_noise_ceiling  # lazy
+        nc_split = cfg.get("noise_ceiling_split") or "test"
+        nc_n = int(cfg.get("noise_ceiling_n") or 10)
+        for sid in subject_ids:
+            ondisk_ceilings[sid] = load_noise_ceiling(
+                subject_id=sid, root=cfg.get("data_root"),
+                split=nc_split, n=nc_n,
+            )
 
     for sid in subject_ids:
         logger.info("loading subject %d", sid)
@@ -287,24 +334,40 @@ def run_study(
         summary, lesion = run_one_subject(
             rec, alphas=alphas, cv=cv, mask=mask,
             device=device, backend=backend,
+            ceiling=ondisk_ceilings.get(sid),
         )
         per_subject.append(summary)
         lesion_objs[sid] = lesion
+        roi_by_subject[sid] = rec["roi_indices"]
         responses_for_ceiling.append(rec["y_test"])
 
-    # Group-level noise ceiling (only meaningful with multiple subjects).
+    # Inter-subject ceiling: computed post-hoc from the loaded responses.
+    # Only runs when explicitly requested (or as a legacy fallback when
+    # more than one subject is loaded and no ceiling source was specified).
     ceiling_mean = None
-    if len(subject_ids) >= 2:
+    want_inter = ceiling_source == "inter-subject" or (
+        ceiling_source == "none" and len(subject_ids) >= 2 and not mock
+    )
+    if want_inter and len(subject_ids) >= 2:
         stack = np.stack(responses_for_ceiling, axis=0)  # (S, n_test, n_vox)
         if stack.shape[0] >= 2:
             ceil = inter_subject_ceiling(stack)
             ceiling_mean = float(ceil.mean())
             np.save(output_dir / "noise_ceiling.npy", ceil)
-            # Re-report normalized scores per subject.
+            # Re-report normalized scores per subject using the whole-group ceiling.
             for s_summary, sid in zip(per_subject, subject_ids):
                 full_r2 = lesion_objs[sid].full_r2.cpu().numpy()
                 normalized = normalize_by_ceiling(full_r2, ceil)
                 s_summary["full_r2_ceiling_normalized_mean"] = float(normalized.mean())
+                # Refresh the per-ROI table with the inter-subject ceiling so
+                # downstream plots don't mix the on-disk and computed variants.
+                s_summary["roi_summary"] = roi_summary(
+                    lesion_objs[sid], roi_by_subject[sid], ceiling=ceil,
+                )
+
+    # Persist per-subject on-disk ceilings for downstream notebooks.
+    for sid, ceiling in ondisk_ceilings.items():
+        np.save(output_dir / f"subject_{sid:02d}_noise_ceiling.npy", ceiling)
 
     manifest = {
         "n_subjects": len(subject_ids),
@@ -318,6 +381,7 @@ def run_study(
         "mock": mock,
         "results": per_subject,
         "group_ceiling_mean": ceiling_mean,
+        "noise_ceiling_source": ceiling_source,
     }
     (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
 
@@ -361,6 +425,12 @@ def main() -> None:
         cfg["lh_annot"] = args.lh_annot
     if args.rh_annot is not None:
         cfg["rh_annot"] = args.rh_annot
+    if args.noise_ceiling:
+        cfg["noise_ceiling"] = args.noise_ceiling
+    if args.noise_ceiling_n is not None:
+        cfg["noise_ceiling_n"] = args.noise_ceiling_n
+    if args.noise_ceiling_split:
+        cfg["noise_ceiling_split"] = args.noise_ceiling_split
     if args.parcellation_rois:
         cfg["parcellation_rois"] = [
             r.strip() for r in args.parcellation_rois.split(",") if r.strip()

--- a/src/cortexlab/analysis/lesion.py
+++ b/src/cortexlab/analysis/lesion.py
@@ -207,6 +207,8 @@ def run_modality_lesion(
 def roi_summary(
     result: LesionResult,
     roi_indices: Mapping[str, np.ndarray],
+    ceiling: np.ndarray | None = None,
+    min_ceiling: float = 0.01,
 ) -> dict[str, dict[str, float]]:
     """Aggregate a LesionResult over ROIs.
 
@@ -217,20 +219,48 @@ def roi_summary(
     roi_indices
         Mapping ROI name to numpy array of voxel indices (as in the
         project's ``roi_indices`` fixture).
+    ceiling
+        Optional per-voxel noise ceiling in R^2 space, shape
+        ``(n_voxels,)``. When provided, each ROI row gains a
+        ``full_r2_normalized`` entry (model R^2 divided by ceiling per
+        voxel, averaged over the ROI) and a ``ceiling_mean`` entry so
+        downstream tables can report both raw and ceiling-normalized
+        scores.
+    min_ceiling
+        Voxels with ceiling below this threshold are dropped from the
+        normalized mean to avoid division instability.
 
     Returns
     -------
     dict
         ``{roi: {"full_r2": float, "dR2_<m>": float, ...}}``, values
-        are ROI-mean scores.
+        are ROI-mean scores. Adds ``full_r2_normalized`` and
+        ``ceiling_mean`` per ROI when ``ceiling`` is provided.
     """
     out: dict[str, dict[str, float]] = {}
     full = result.full_r2.cpu().numpy()
     dr2 = {m: result.delta_r2[m].cpu().numpy() for m in result.modality_order}
+
+    if ceiling is not None:
+        ceiling = np.asarray(ceiling)
+        if ceiling.shape != full.shape:
+            raise ValueError(
+                f"ceiling shape {ceiling.shape} does not match full_r2 {full.shape}"
+            )
+
     for roi, idx in roi_indices.items():
         row = {"full_r2": float(np.mean(full[idx]))}
         for m in result.modality_order:
             row[f"dR2_{m}"] = float(np.mean(dr2[m][idx]))
+        if ceiling is not None:
+            c_roi = ceiling[idx]
+            mask = c_roi > min_ceiling
+            if mask.any():
+                normalized = full[idx][mask] / c_roi[mask]
+                row["full_r2_normalized"] = float(np.mean(normalized))
+            else:
+                row["full_r2_normalized"] = float("nan")
+            row["ceiling_mean"] = float(np.mean(c_roi))
         out[roi] = row
     return out
 

--- a/src/cortexlab/data/studies/lahner2024bold.py
+++ b/src/cortexlab/data/studies/lahner2024bold.py
@@ -474,6 +474,132 @@ def load_subject(
     }
 
 
+NOISE_CEILING_FILENAME_TEMPLATE: tp.Final[str] = (
+    "sub-{subject_id:02d}_organized_noiseceiling_task-{split}_hemi-{hemi}_n-{n}.pkl"
+)
+"""Filename convention used by the BOLD Moments authors for pre-computed
+noise ceilings, as shipped under ``prepared_betas/`` alongside the betas.
+Both the ``n-10`` (all subjects) and ``n-k`` (subset) variants follow this
+template."""
+
+
+def load_noise_ceiling(
+    subject_id: int,
+    root: str | os.PathLike | None = None,
+    split: str = "test",
+    n: int = 10,
+) -> np.ndarray:
+    """Load the BOLD Moments on-disk noise ceiling for one subject.
+
+    The Lahner 2024 release ships pre-computed noise ceilings as
+    per-hemisphere pickles alongside the prepared betas. Each pickle holds
+    a 1-D array of length :data:`N_VERTICES_PER_HEMI` (163842) with the
+    per-vertex ceiling in ``R^2`` (squared Pearson correlation) space,
+    computed across ``n`` subjects. The ``n=10`` variant is the default
+    and is what ceiling-normalized model scores should be compared
+    against.
+
+    Parameters
+    ----------
+    subject_id
+        1 through 10. The noise ceiling is per-subject because it uses a
+        leave-one-out construction against the other ``n-1`` subjects'
+        mean response.
+    root
+        Dataset root. Falls back to ``CORTEXLAB_DATA`` when None, same
+        resolution rules as :func:`load_subject`.
+    split
+        ``"train"`` or ``"test"``. Typically ``"test"`` is the only one
+        used in practice, because the 102-clip test split's 10
+        repetitions make the ceiling estimator robust.
+    n
+        The ``n`` suffix in the filename (subjects used to build the
+        ceiling). BOLD Moments ships ``n=10``.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(2 * N_VERTICES_PER_HEMI,)`` = ``(327684,)``, dtype
+        ``float32``. Left hemisphere first, right hemisphere second,
+        matching the vertex layout used by :func:`load_subject`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If either per-hemisphere pickle is missing.
+    ValueError
+        If the loaded array has the wrong shape.
+
+    Notes
+    -----
+    The on-disk ceiling and :func:`cortexlab.analysis.noise_ceiling.inter_subject_ceiling`
+    compute essentially the same quantity. Use the on-disk file when you
+    want the authors' canonical value; use the in-memory helper when you
+    want the ceiling restricted to the subjects you actually loaded.
+    """
+    if split not in ("train", "test"):
+        raise ValueError(f"split must be 'train' or 'test'; got {split!r}")
+
+    root_path = _resolve_root(root)
+    betas_root = root_path / BETAS_SUBPATH / f"sub-{subject_id:02d}" / "prepared_betas"
+    if not betas_root.is_dir():
+        raise FileNotFoundError(
+            f"expected prepared betas under {betas_root}; cannot find noise ceiling."
+        )
+
+    hemi_arrays: list[np.ndarray] = []
+    for hemi in ("left", "right"):
+        fname = NOISE_CEILING_FILENAME_TEMPLATE.format(
+            subject_id=subject_id, split=split, hemi=hemi, n=n,
+        )
+        fp = betas_root / fname
+        if not fp.exists():
+            raise FileNotFoundError(
+                f"missing noise-ceiling file {fp}. "
+                f"Expected the Lahner 2024 convention {NOISE_CEILING_FILENAME_TEMPLATE!r}."
+            )
+        with fp.open("rb") as f:
+            obj = pkl.load(f)
+        arr = _unwrap_ceiling_payload(obj)
+        if arr.shape != (N_VERTICES_PER_HEMI,):
+            raise ValueError(
+                f"{fp.name}: expected ceiling shape ({N_VERTICES_PER_HEMI},), "
+                f"got {arr.shape}"
+            )
+        hemi_arrays.append(arr.astype(np.float32, copy=False))
+
+    ceiling = np.concatenate(hemi_arrays, axis=0)
+    logger.info(
+        "loaded noise ceiling for sub-%02d/%s (n=%d): mean=%.3f, median=%.3f",
+        subject_id, split, n, float(ceiling.mean()), float(np.median(ceiling)),
+    )
+    return ceiling
+
+
+def _unwrap_ceiling_payload(obj: tp.Any) -> np.ndarray:
+    """Coerce a pickled ceiling object to a 1-D numpy array.
+
+    The BOLD Moments release stores the ceiling straight as a numpy array
+    in some distributions and as a single-element tuple in others (the
+    pickled container inherits the author's intermediate processing
+    layout). Accept either and anything that exposes an ``.array``-like
+    view; raise ``TypeError`` otherwise so the user sees a clear message
+    instead of a numpy shape error three layers down.
+    """
+    if isinstance(obj, np.ndarray):
+        arr = obj
+    elif isinstance(obj, (tuple, list)) and obj:
+        arr = np.asarray(obj[0])
+    elif hasattr(obj, "__array__"):
+        arr = np.asarray(obj)
+    else:
+        raise TypeError(
+            f"unexpected noise-ceiling payload type {type(obj).__name__}; "
+            "expected numpy array or tuple whose first element is an array."
+        )
+    return np.squeeze(arr)
+
+
 class Lahner2024Bold(study.Study):
     device: tp.ClassVar[str] = "Fmri"
     dataset_name: tp.ClassVar[str] = "BOLD Moments"

--- a/tests/test_lahner_noise_ceiling.py
+++ b/tests/test_lahner_noise_ceiling.py
@@ -1,0 +1,184 @@
+"""Tests for :func:`cortexlab.data.studies.lahner2024bold.load_noise_ceiling`.
+
+Synthesizes a tiny on-disk mirror of the BOLD Moments
+``prepared_betas/`` layout for one subject, writes per-hemisphere
+ceiling pickles in the author's naming convention, and exercises the
+loader's parsing and error paths without needing the real dataset.
+"""
+
+from __future__ import annotations
+
+import pickle as pkl
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cortexlab.data.studies.lahner2024bold import (
+    BETAS_SUBPATH,
+    NOISE_CEILING_FILENAME_TEMPLATE,
+    load_noise_ceiling,
+)
+
+
+@pytest.fixture
+def tiny_vertices(monkeypatch):
+    """Shrink N_VERTICES_PER_HEMI so tiny synthetic pickles are valid."""
+    monkeypatch.setattr(
+        "cortexlab.data.studies.lahner2024bold.N_VERTICES_PER_HEMI", 16,
+    )
+    return 16
+
+
+def _write_ceiling(
+    root: Path,
+    subject_id: int,
+    split: str,
+    n: int,
+    lh: np.ndarray,
+    rh: np.ndarray,
+    *,
+    payload_wrap: str = "array",
+) -> None:
+    """Write both hemisphere ceiling pickles for one subject.
+
+    ``payload_wrap`` selects how the per-hemisphere array is stored:
+    ``"array"`` plain ndarray, ``"tuple"`` single-element tuple,
+    ``"list"`` single-element list.
+    """
+    sub_dir = root / BETAS_SUBPATH / f"sub-{subject_id:02d}" / "prepared_betas"
+    sub_dir.mkdir(parents=True, exist_ok=True)
+    for hemi, arr in (("left", lh), ("right", rh)):
+        fp = sub_dir / NOISE_CEILING_FILENAME_TEMPLATE.format(
+            subject_id=subject_id, split=split, hemi=hemi, n=n,
+        )
+        if payload_wrap == "array":
+            payload = arr
+        elif payload_wrap == "tuple":
+            payload = (arr,)
+        elif payload_wrap == "list":
+            payload = [arr]
+        else:
+            raise ValueError(payload_wrap)
+        with fp.open("wb") as f:
+            pkl.dump(payload, f)
+
+
+# --------------------------------------------------------------------------- #
+# happy path                                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_load_noise_ceiling_shape_and_dtype(tmp_path, tiny_vertices):
+    lh = np.linspace(0.0, 0.5, tiny_vertices, dtype=np.float32)
+    rh = np.linspace(0.2, 0.8, tiny_vertices, dtype=np.float32)
+    _write_ceiling(tmp_path, subject_id=1, split="test", n=10, lh=lh, rh=rh)
+
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path, split="test", n=10)
+    assert ceiling.shape == (2 * tiny_vertices,)
+    assert ceiling.dtype == np.float32
+    np.testing.assert_allclose(ceiling[:tiny_vertices], lh)
+    np.testing.assert_allclose(ceiling[tiny_vertices:], rh)
+
+
+def test_load_noise_ceiling_accepts_tuple_payload(tmp_path, tiny_vertices):
+    lh = np.random.default_rng(0).random(tiny_vertices).astype(np.float32)
+    rh = np.random.default_rng(1).random(tiny_vertices).astype(np.float32)
+    _write_ceiling(tmp_path, 1, "test", 10, lh, rh, payload_wrap="tuple")
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path)
+    assert ceiling.shape == (2 * tiny_vertices,)
+
+
+def test_load_noise_ceiling_accepts_list_payload(tmp_path, tiny_vertices):
+    lh = np.zeros(tiny_vertices, dtype=np.float32)
+    rh = np.ones(tiny_vertices, dtype=np.float32) * 0.3
+    _write_ceiling(tmp_path, 1, "test", 10, lh, rh, payload_wrap="list")
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path)
+    assert abs(ceiling.mean() - 0.15) < 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# split + n variations                                                        #
+# --------------------------------------------------------------------------- #
+
+def test_load_noise_ceiling_train_split(tmp_path, tiny_vertices):
+    lh = np.full(tiny_vertices, 0.25, dtype=np.float32)
+    rh = np.full(tiny_vertices, 0.35, dtype=np.float32)
+    _write_ceiling(tmp_path, 1, "train", 10, lh, rh)
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path, split="train")
+    assert ceiling.shape == (2 * tiny_vertices,)
+    assert abs(ceiling[:tiny_vertices].mean() - 0.25) < 1e-6
+
+
+def test_load_noise_ceiling_nondefault_n(tmp_path, tiny_vertices):
+    lh = np.full(tiny_vertices, 0.1, dtype=np.float32)
+    rh = np.full(tiny_vertices, 0.1, dtype=np.float32)
+    _write_ceiling(tmp_path, 1, "test", n=5, lh=lh, rh=rh)
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path, n=5)
+    assert ceiling.shape == (2 * tiny_vertices,)
+
+
+# --------------------------------------------------------------------------- #
+# error paths                                                                 #
+# --------------------------------------------------------------------------- #
+
+def test_load_noise_ceiling_rejects_bad_split(tmp_path, tiny_vertices):
+    with pytest.raises(ValueError, match="split must be"):
+        load_noise_ceiling(subject_id=1, root=tmp_path, split="val")
+
+
+def test_load_noise_ceiling_missing_betas_dir(tmp_path, tiny_vertices):
+    with pytest.raises(FileNotFoundError, match="prepared betas"):
+        load_noise_ceiling(subject_id=1, root=tmp_path)
+
+
+def test_load_noise_ceiling_missing_hemisphere_file(tmp_path, tiny_vertices):
+    lh = np.zeros(tiny_vertices, dtype=np.float32)
+    rh = np.zeros(tiny_vertices, dtype=np.float32)
+    _write_ceiling(tmp_path, 1, "test", 10, lh, rh)
+    # Remove the right-hemisphere file to simulate an incomplete staging.
+    fp_rh = (
+        tmp_path / BETAS_SUBPATH / "sub-01" / "prepared_betas"
+        / NOISE_CEILING_FILENAME_TEMPLATE.format(
+            subject_id=1, split="test", hemi="right", n=10,
+        )
+    )
+    fp_rh.unlink()
+    with pytest.raises(FileNotFoundError, match="noise-ceiling"):
+        load_noise_ceiling(subject_id=1, root=tmp_path)
+
+
+def test_load_noise_ceiling_wrong_shape_raises(tmp_path, tiny_vertices):
+    lh = np.zeros(tiny_vertices + 3, dtype=np.float32)   # wrong length
+    rh = np.zeros(tiny_vertices, dtype=np.float32)
+    _write_ceiling(tmp_path, 1, "test", 10, lh, rh)
+    with pytest.raises(ValueError, match="expected ceiling shape"):
+        load_noise_ceiling(subject_id=1, root=tmp_path)
+
+
+def test_load_noise_ceiling_unknown_payload_type(tmp_path, tiny_vertices):
+    sub_dir = tmp_path / BETAS_SUBPATH / "sub-01" / "prepared_betas"
+    sub_dir.mkdir(parents=True, exist_ok=True)
+    for hemi in ("left", "right"):
+        fp = sub_dir / NOISE_CEILING_FILENAME_TEMPLATE.format(
+            subject_id=1, split="test", hemi=hemi, n=10,
+        )
+        with fp.open("wb") as f:
+            pkl.dump({"oops": "dict"}, f)     # neither array nor tuple
+    with pytest.raises(TypeError, match="unexpected noise-ceiling payload"):
+        load_noise_ceiling(subject_id=1, root=tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# integration: the array is usable by roi_summary                             #
+# --------------------------------------------------------------------------- #
+
+def test_loaded_ceiling_feeds_roi_summary_shape(tmp_path, tiny_vertices):
+    """Sanity: the output is a flat 1-D array of the right length so
+    downstream ``roi_summary(..., ceiling=...)`` calls won't shape-check-fail.
+    """
+    lh = np.full(tiny_vertices, 0.4, dtype=np.float32)
+    rh = np.full(tiny_vertices, 0.6, dtype=np.float32)
+    _write_ceiling(tmp_path, 1, "test", 10, lh, rh)
+    ceiling = load_noise_ceiling(subject_id=1, root=tmp_path)
+    assert ceiling.ndim == 1
+    assert ceiling.size == 2 * tiny_vertices

--- a/tests/test_lesion.py
+++ b/tests/test_lesion.py
@@ -109,6 +109,52 @@ def test_lesion_rejects_single_modality():
                             np.zeros((5, 3), dtype=np.float32))
 
 
+def test_roi_summary_with_ceiling_adds_normalized_column():
+    """Ceiling-aware roi_summary should report both raw and normalized
+    per-ROI R^2, and should skip voxels whose ceiling falls below
+    ``min_ceiling``.
+    """
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(train, test, y_tr, y_te,
+                                 alphas=[1.0], cv=2, mask_strategy="zero")
+    rois = {"text_roi": np.array([0, 1, 2, 3])}
+    # Build a ceiling of the right length where two voxels are well below
+    # the threshold; the other two sit at 0.5 so normalized = full_r2 / 0.5.
+    n_vox = result.full_r2.shape[0]
+    ceiling = np.full(n_vox, 0.5, dtype=np.float32)
+    ceiling[0] = 0.0         # dropped
+    ceiling[1] = 0.001       # below min_ceiling
+    summary = roi_summary(result, rois, ceiling=ceiling)
+
+    assert "full_r2_normalized" in summary["text_roi"]
+    assert "ceiling_mean" in summary["text_roi"]
+    # Normalized average should only average across voxels 2 and 3.
+    full = result.full_r2.cpu().numpy()
+    expected = float((full[2:4] / 0.5).mean())
+    assert abs(summary["text_roi"]["full_r2_normalized"] - expected) < 1e-6
+
+
+def test_roi_summary_rejects_mismatched_ceiling_shape():
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(train, test, y_tr, y_te,
+                                 alphas=[1.0], cv=2, mask_strategy="zero")
+    bad_ceiling = np.zeros(result.full_r2.shape[0] + 5, dtype=np.float32)
+    with pytest.raises(ValueError, match="shape"):
+        roi_summary(result, {"x": np.array([0])}, ceiling=bad_ceiling)
+
+
+def test_roi_summary_without_ceiling_unchanged():
+    """Backward compat: calls without ceiling return the pre-existing schema."""
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(train, test, y_tr, y_te,
+                                 alphas=[1.0], cv=2, mask_strategy="zero")
+    summary = roi_summary(result, {"text_roi": np.array([0, 1])})
+    row = summary["text_roi"]
+    assert "full_r2_normalized" not in row
+    assert "ceiling_mean" not in row
+    assert "full_r2" in row
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_lesion_handles_cuda_device_end_to_end():
     """Regression test: y_test arrives on CPU, encoder moves inputs to


### PR DESCRIPTION
## Summary

Adds a first-class noise-ceiling source to the encoding / lesion pipeline so per-ROI reports can show the **fraction of explainable variance** the model captures, not just raw R^2. This is what brain-encoding papers report and what downstream plots need.

- \`cortexlab.data.studies.lahner2024bold.load_noise_ceiling(subject_id, root, split, n)\` reads the BOLD Moments authors' on-disk per-subject ceiling pickles (\`n-10\` by default) and returns a flat \`(2 * N_VERTICES_PER_HEMI,) = (327684,)\` array aligned with the betas layout. Payload parsing accepts plain ndarray, single-element tuple, and single-element list so the loader survives packaging differences across release variants.
- \`cortexlab.analysis.lesion.roi_summary\` grows an optional \`ceiling=\` kwarg. When supplied, every ROI row gains \`full_r2_normalized\` (mean of \`full_r2 / ceiling\` across voxels whose ceiling exceeds \`min_ceiling\`) and \`ceiling_mean\`. Shape-mismatched ceilings raise a clear \`ValueError\` up front. Schema is unchanged when \`ceiling=None\` (backward compat).
- \`experiments/causal_modality_ablation.py\` gains three flags:
  - \`--noise-ceiling {none, bold-moments, inter-subject}\`
  - \`--noise-ceiling-n\` (default 10)
  - \`--noise-ceiling-split {train, test}\` (default test)

  \`bold-moments\` loads per-subject ceilings up front. \`inter-subject\` reuses the existing post-hoc leave-one-subject-out computation and now also refreshes the per-ROI summary with the computed ceiling so downstream plots don't mix units.
- Per-subject ceilings are persisted as \`subject_XX_noise_ceiling.npy\` next to the lesion \`.npz\` results; the manifest records \`noise_ceiling_source\` so analysis notebooks can tell which path produced the numbers.
- 17 new tests cover the loader (shape, dtype, tuple / list payload shims, train vs. test split, non-default n, missing files, wrong shape, unknown payload type) and the ceiling-aware roi_summary (normalized column, min-ceiling masking, shape mismatch rejection, backward compat).

No data files are committed; the module is path-agnostic.

## Why both sources?

- \`bold-moments\`: the canonical ceiling for this dataset. Use it when you want numbers that match the authors' tables.
- \`inter-subject\`: lets you recompute a ceiling over just the subjects you loaded (useful for small-N pilots and for datasets without a pre-computed ceiling).

Both paths flow through the same \`normalize_by_ceiling\` + \`roi_summary\` plumbing, so the per-ROI column names are identical regardless of source.

## Test plan

- [x] \`python -m pytest tests/test_lahner_noise_ceiling.py tests/test_lesion.py -v\` -> 19 passed, 1 skipped (CUDA)
- [x] \`python -m pytest tests/ -q\` -> 231 passed, 3 skipped (no regressions)
- [x] \`python -m experiments.causal_modality_ablation --help\` shows the three new noise-ceiling flags
- [x] \`python -m experiments.causal_modality_ablation --mock --subjects 1 --pilot 50 ... --noise-ceiling none\` still runs end-to-end on CPU
- [ ] Real run on Jarvis with \`--noise-ceiling bold-moments\` once the ceiling pkl files are confirmed staged

---
_Original PR #47 was auto-closed when its base branch `feat/hcp-mmp-parcellation` was deleted post-merge of #46. This is the same branch rebased onto master with the stacked HCP commit dropped (it is now on master via squash-merge `feea5f3`)._