### PR TITLE
feat(analysis): row-permutation test per modality for lesion

### DIFF
--- a/experiments/causal_modality_ablation.py
+++ b/experiments/causal_modality_ablation.py
@@ -114,6 +114,12 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--noise-ceiling-split", type=str, default="test",
                     choices=["train", "test"],
                     help="Which split's on-disk ceiling to load from BOLD Moments.")
+    ap.add_argument("--permutations", type=int, default=0,
+                    help="If >0, run a row-permutation test per modality with "
+                         "this many shuffles; p-values land in roi_summary "
+                         "as p_<m>_median and frac_sig_<m>. 0 skips.")
+    ap.add_argument("--permutation-seed", type=int, default=0,
+                    help="RNG seed for reproducible permutations.")
     return ap.parse_args()
 
 
@@ -237,6 +243,8 @@ def run_one_subject(
     device: str,
     backend: str,
     ceiling: np.ndarray | None = None,
+    n_permutations: int = 0,
+    permutation_seed: int = 0,
 ) -> dict:
     """Fit encoder, run lesion, summarize over ROIs.
 
@@ -251,6 +259,8 @@ def run_one_subject(
         rec["y_train"], rec["y_test"],
         alphas=alphas, cv=cv, mask_strategy=mask,
         device=device, backend=backend,
+        n_permutations=n_permutations,
+        permutation_seed=permutation_seed,
     )
     elapsed = time.perf_counter() - t0
     logger.info("subject %s: lesion done in %.1fs", rec["subject_id"], elapsed)
@@ -281,6 +291,16 @@ def run_one_subject(
         else:
             payload["full_r2_normalized_mean"] = float("nan")
         payload["ceiling_mean"] = float(ceiling.mean())
+    if result.p_values is not None:
+        payload["n_permutations"] = result.n_permutations
+        payload["p_value_medians"] = {
+            m: float(result.p_values[m].median().item())
+            for m in result.modality_order
+        }
+        payload["frac_sig_at_05"] = {
+            m: float((result.p_values[m] < 0.05).float().mean().item())
+            for m in result.modality_order
+        }
     return payload, result
 
 
@@ -335,6 +355,8 @@ def run_study(
             rec, alphas=alphas, cv=cv, mask=mask,
             device=device, backend=backend,
             ceiling=ondisk_ceilings.get(sid),
+            n_permutations=int(cfg.get("permutations") or 0),
+            permutation_seed=int(cfg.get("permutation_seed") or 0),
         )
         per_subject.append(summary)
         lesion_objs[sid] = lesion
@@ -364,6 +386,9 @@ def run_study(
                 s_summary["roi_summary"] = roi_summary(
                     lesion_objs[sid], roi_by_subject[sid], ceiling=ceil,
                 )
+                # Re-attach per-ROI permutation fields (roi_summary
+                # re-reads result.p_values on every call, so this is a
+                # no-op when permutations=0).
 
     # Persist per-subject on-disk ceilings for downstream notebooks.
     for sid, ceiling in ondisk_ceilings.items():
@@ -387,13 +412,18 @@ def run_study(
 
     # Also save per-subject raw LesionResult arrays for downstream viz.
     for sid, lr in lesion_objs.items():
-        np.savez_compressed(
-            output_dir / f"subject_{sid:02d}_lesion.npz",
-            full_r2=lr.full_r2.cpu().numpy(),
+        arrays = {
+            "full_r2": lr.full_r2.cpu().numpy(),
+            "best_alpha": lr.best_alpha.cpu().numpy(),
             **{f"delta_{m}": lr.delta_r2[m].cpu().numpy()
                for m in lr.modality_order},
-            best_alpha=lr.best_alpha.cpu().numpy(),
-        )
+        }
+        if lr.p_values is not None:
+            arrays.update({
+                f"p_{m}": lr.p_values[m].cpu().numpy()
+                for m in lr.modality_order
+            })
+        np.savez_compressed(output_dir / f"subject_{sid:02d}_lesion.npz", **arrays)
 
     logger.info("wrote %d subject result(s) to %s",
                 len(subject_ids), output_dir)
@@ -435,6 +465,10 @@ def main() -> None:
         cfg["parcellation_rois"] = [
             r.strip() for r in args.parcellation_rois.split(",") if r.strip()
         ]
+    if args.permutations is not None:
+        cfg["permutations"] = args.permutations
+    if args.permutation_seed is not None:
+        cfg["permutation_seed"] = args.permutation_seed
 
     alphas = [float(a) for a in args.alphas.split(",")]
 

--- a/src/cortexlab/analysis/lesion.py
+++ b/src/cortexlab/analysis/lesion.py
@@ -66,6 +66,17 @@ class LesionResult:
         Number of held-out test stimuli used to score predictions.
     best_alpha
         Per-voxel selected ridge alpha (diagnostic).
+    p_values
+        When :func:`run_modality_lesion` is called with
+        ``n_permutations > 0``, ``p_values[m]`` is a ``(n_voxels,)``
+        float32 tensor of one-sided p-values for the null that
+        modality ``m``'s test-time features are uninformative
+        (constructed by row-permuting ``X_test[:, slice(m)]``).
+        Smaller values mean the observed ``delta_r2[m]`` is unlikely
+        under the null. ``None`` when no permutation test was run.
+    n_permutations
+        Number of random permutations used; 0 when no permutation test
+        was performed.
     """
 
     full_r2: torch.Tensor
@@ -75,6 +86,8 @@ class LesionResult:
     n_train: int
     n_test: int
     best_alpha: torch.Tensor = field(default_factory=lambda: torch.empty(0))
+    p_values: dict[str, torch.Tensor] | None = None
+    n_permutations: int = 0
 
 
 def run_modality_lesion(
@@ -87,6 +100,8 @@ def run_modality_lesion(
     mask_strategy: MaskStrategy = "zero",
     device: str | None = None,
     backend: str = "auto",
+    n_permutations: int = 0,
+    permutation_seed: int = 0,
 ) -> LesionResult:
     """Run the causal modality lesion protocol.
 
@@ -108,6 +123,17 @@ def run_modality_lesion(
         Torch device for the ridge solve.
     backend
         Ridge backend: ``"torch"``, ``"triton"``, or ``"auto"``.
+    n_permutations
+        If > 0, run a modality-wise label-permutation test against the
+        null that modality ``m``'s test features are uninformative. For
+        each of ``n_permutations`` random permutations, the rows of
+        ``X_test[:, slice(m)]`` are shuffled across stimuli (the encoder
+        is NOT refit) and the resulting ``delta_r2_null`` compared to
+        the observed ``delta_r2``. Per-voxel one-sided p-values
+        (``(count(null >= observed) + 1) / (n_permutations + 1)``) are
+        returned in ``LesionResult.p_values``.
+    permutation_seed
+        RNG seed for reproducible permutations.
 
     Returns
     -------
@@ -180,6 +206,7 @@ def run_modality_lesion(
     # modalities. We keep the original encoder and ask "what if this
     # modality had been absent at inference time?".
     delta: dict[str, torch.Tensor] = {}
+    r2_ablated: dict[str, torch.Tensor] = {}
     for m in modality_order:
         X_test_ablated = X_test.clone()
         sl = slices[m]
@@ -187,11 +214,61 @@ def run_modality_lesion(
         Y_hat_m = enc.predict(X_test_ablated)
         r2_m = _r2_score(Y_test, Y_hat_m)
         delta[m] = r2_full - r2_m
+        r2_ablated[m] = r2_m
         logger.info(
             "  lesion %s: mean dR^2 = %+.4f (top quintile %+.4f)",
             m, delta[m].mean().item(),
             delta[m].quantile(0.8).item(),
         )
+
+    # Optional permutation test: shuffle the test-time stimulus order of
+    # modality m's feature block only (leaving the other modalities' rows
+    # intact) and re-evaluate. Under the null "modality m adds nothing at
+    # test time", delta_null should be distributed around delta_observed;
+    # under the alternative, delta_observed is much larger.
+    p_values: dict[str, torch.Tensor] | None = None
+    if n_permutations > 0:
+        if n_permutations < 0:
+            raise ValueError(f"n_permutations must be >= 0, got {n_permutations}")
+        n_test = X_test.shape[0]
+        n_vox = int(Y_test.shape[1])
+        # Seeded RNG on CPU so permutations are reproducible regardless
+        # of target_device (CUDA randperm with a generator is fiddly).
+        rng = torch.Generator(device="cpu").manual_seed(int(permutation_seed))
+        counts = {
+            m: torch.zeros(n_vox, dtype=torch.int32, device=target_device)
+            for m in modality_order
+        }
+        for b in range(n_permutations):
+            perm = torch.randperm(n_test, generator=rng).to(target_device)
+            for m in modality_order:
+                sl = slices[m]
+                X_perm = X_test.clone()
+                X_perm[:, sl] = X_test[perm][:, sl]
+                Y_hat_null = enc.predict(X_perm)
+                r2_full_null = _r2_score(Y_test, Y_hat_null)
+                # The ablated prediction is invariant under this
+                # row-permutation because the slice is replaced by a
+                # constant mask; reuse the observed r2_ablated[m].
+                delta_null = r2_full_null - r2_ablated[m]
+                counts[m] += (delta_null >= delta[m]).to(torch.int32)
+            if (b + 1) % max(1, n_permutations // 10) == 0:
+                logger.info(
+                    "  permutation %d / %d done",
+                    b + 1, n_permutations,
+                )
+        # "+1" smoothing so p is never exactly zero when none of the
+        # nulls exceeded observed (classic Phipson & Smyth 2010 fix).
+        p_values = {
+            m: (counts[m].to(torch.float32) + 1.0) / (n_permutations + 1.0)
+            for m in modality_order
+        }
+        for m in modality_order:
+            frac_sig = float((p_values[m] < 0.05).float().mean().item())
+            logger.info(
+                "  %s: median p = %.3f, fraction p<0.05 = %.3f",
+                m, float(p_values[m].median().item()), frac_sig,
+            )
 
     return LesionResult(
         full_r2=r2_full,
@@ -201,6 +278,8 @@ def run_modality_lesion(
         n_train=int(Y_train.shape[0]),
         n_test=int(Y_test.shape[0]),
         best_alpha=enc.best_alpha_,
+        p_values=p_values,
+        n_permutations=int(n_permutations),
     )
 
 
@@ -235,11 +314,17 @@ def roi_summary(
     dict
         ``{roi: {"full_r2": float, "dR2_<m>": float, ...}}``, values
         are ROI-mean scores. Adds ``full_r2_normalized`` and
-        ``ceiling_mean`` per ROI when ``ceiling`` is provided.
+        ``ceiling_mean`` per ROI when ``ceiling`` is provided. Adds
+        ``p_<m>_median`` and ``frac_sig_<m>`` (at alpha=0.05) per ROI
+        when ``result.p_values`` is populated by
+        :func:`run_modality_lesion` with ``n_permutations > 0``.
     """
     out: dict[str, dict[str, float]] = {}
     full = result.full_r2.cpu().numpy()
     dr2 = {m: result.delta_r2[m].cpu().numpy() for m in result.modality_order}
+    p_vals: dict[str, np.ndarray] | None = None
+    if result.p_values is not None:
+        p_vals = {m: result.p_values[m].cpu().numpy() for m in result.modality_order}
 
     if ceiling is not None:
         ceiling = np.asarray(ceiling)
@@ -252,6 +337,9 @@ def roi_summary(
         row = {"full_r2": float(np.mean(full[idx]))}
         for m in result.modality_order:
             row[f"dR2_{m}"] = float(np.mean(dr2[m][idx]))
+            if p_vals is not None:
+                row[f"p_{m}_median"] = float(np.median(p_vals[m][idx]))
+                row[f"frac_sig_{m}"] = float(np.mean(p_vals[m][idx] < 0.05))
         if ceiling is not None:
             c_roi = ceiling[idx]
             mask = c_roi > min_ceiling

--- a/tests/test_lesion.py
+++ b/tests/test_lesion.py
@@ -155,6 +155,135 @@ def test_roi_summary_without_ceiling_unchanged():
     assert "full_r2" in row
 
 
+# --------------------------------------------------------------------------- #
+# permutation test                                                            #
+# --------------------------------------------------------------------------- #
+
+def test_permutation_test_produces_small_p_for_true_signal():
+    """When a modality genuinely drives voxels, permuting its test-time
+    rows should make those voxels' delta_R^2 shrink, so the observed
+    delta should sit near the top of the null distribution and the
+    corresponding p-values should be small."""
+    train, test, y_tr, y_te, assignments = _synth_multimodal(noise=0.05)
+    result = run_modality_lesion(
+        train, test, y_tr, y_te,
+        alphas=[1e-2, 1.0, 1e2], cv=3, mask_strategy="zero",
+        n_permutations=200, permutation_seed=0,
+    )
+    assert result.p_values is not None
+    assert result.n_permutations == 200
+    # For each modality's true voxels, at least most should be significant.
+    for m, sl in assignments.items():
+        p_m = result.p_values[m][sl.start:sl.stop].cpu().numpy()
+        frac_sig = (p_m < 0.05).mean()
+        assert frac_sig > 0.5, (
+            f"modality {m}: expected most true voxels significant, "
+            f"got frac_sig={frac_sig:.2f}, p={p_m}"
+        )
+
+
+def test_permutation_test_large_p_for_noise_voxels():
+    """Voxels that don't depend on modality m should have p-values that
+    are NOT uniformly tiny. We allow some leakage through ridge
+    regularization but demand it doesn't look like a clean signal."""
+    train, test, y_tr, y_te, assignments = _synth_multimodal(noise=0.05)
+    result = run_modality_lesion(
+        train, test, y_tr, y_te,
+        alphas=[1.0], cv=2, mask_strategy="zero",
+        n_permutations=200, permutation_seed=1,
+    )
+    text_sl = assignments["text"]
+    for m in ("audio", "video"):
+        p_m = result.p_values[m][text_sl.start:text_sl.stop].cpu().numpy()
+        frac_sig = (p_m < 0.05).mean()
+        assert frac_sig <= 0.5, (
+            f"null-modality {m} on text voxels: too many false positives "
+            f"(frac_sig={frac_sig:.2f})"
+        )
+
+
+def test_permutation_test_zero_permutations_keeps_p_none():
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(
+        train, test, y_tr, y_te,
+        alphas=[1.0], cv=2, mask_strategy="zero",
+        n_permutations=0,
+    )
+    assert result.p_values is None
+    assert result.n_permutations == 0
+
+
+def test_permutation_test_reproducible_with_seed():
+    """Same seed => identical p-values; different seed => different."""
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    kwargs = dict(
+        alphas=[1.0], cv=2, mask_strategy="zero",
+        n_permutations=50,
+    )
+    a = run_modality_lesion(train, test, y_tr, y_te,
+                            permutation_seed=7, **kwargs)
+    b = run_modality_lesion(train, test, y_tr, y_te,
+                            permutation_seed=7, **kwargs)
+    c = run_modality_lesion(train, test, y_tr, y_te,
+                            permutation_seed=13, **kwargs)
+    for m in a.modality_order:
+        assert torch.equal(a.p_values[m], b.p_values[m]), f"seed reproducibility broken for {m}"
+        assert not torch.equal(a.p_values[m], c.p_values[m])
+
+
+def test_permutation_p_values_respect_one_sided_bounds():
+    """All p-values live in [1/(B+1), 1] because of the Phipson-Smyth +1 smoothing."""
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(
+        train, test, y_tr, y_te,
+        alphas=[1.0], cv=2, mask_strategy="zero",
+        n_permutations=10, permutation_seed=0,
+    )
+    expected_floor = 1.0 / (10 + 1)
+    for m in result.modality_order:
+        p = result.p_values[m]
+        assert (p >= expected_floor - 1e-6).all()
+        assert (p <= 1.0 + 1e-6).all()
+
+
+def test_roi_summary_exposes_permutation_columns():
+    """roi_summary should surface p-value aggregates per ROI when the
+    LesionResult has populated p_values."""
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(
+        train, test, y_tr, y_te,
+        alphas=[1.0], cv=2, mask_strategy="zero",
+        n_permutations=50, permutation_seed=0,
+    )
+    rois = {
+        "text_roi":  np.array([0, 1, 2, 3]),
+        "audio_roi": np.array([4, 5, 6, 7]),
+        "video_roi": np.array([8, 9, 10, 11]),
+    }
+    summary = roi_summary(result, rois)
+    for roi_name in rois:
+        row = summary[roi_name]
+        for m in result.modality_order:
+            assert f"p_{m}_median" in row
+            assert f"frac_sig_{m}" in row
+            assert 0.0 <= row[f"p_{m}_median"] <= 1.0
+            assert 0.0 <= row[f"frac_sig_{m}"] <= 1.0
+    # The "own" modality should be at least as significant as the non-owner ones.
+    assert summary["text_roi"]["p_text_median"] <= summary["text_roi"]["p_audio_median"]
+    assert summary["audio_roi"]["p_audio_median"] <= summary["audio_roi"]["p_video_median"]
+
+
+def test_roi_summary_without_permutations_omits_p_columns():
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(train, test, y_tr, y_te,
+                                 alphas=[1.0], cv=2, mask_strategy="zero")
+    summary = roi_summary(result, {"text_roi": np.array([0, 1, 2, 3])})
+    row = summary["text_roi"]
+    for m in result.modality_order:
+        assert f"p_{m}_median" not in row
+        assert f"frac_sig_{m}" not in row
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_lesion_handles_cuda_device_end_to_end():
     """Regression test: y_test arrives on CPU, encoder moves inputs to


### PR DESCRIPTION
## Summary

Adds significance testing to the lesion protocol so per-ROI tables can answer the first question any brain-encoding reviewer asks: "is this region's modality preference distinguishable from zero?"

- \`run_modality_lesion\` grows \`n_permutations\` and \`permutation_seed\` kwargs. When \`n_permutations > 0\`, the function shuffles rows of \`X_test[:, slice(m)]\` across test stimuli for each modality \`m\`, re-predicts with the fixed encoder (no refit), and compares the resulting \`delta_R^2_null\` to the observed \`delta_R^2\`. Per-voxel one-sided p-values use the Phipson & Smyth (2010) \`+1\` smoothing convention so no p is ever exactly zero, and they live in \`LesionResult.p_values[m]\` next to \`delta_r2[m]\`.
- \`LesionResult\` gains \`p_values: dict[str, Tensor] | None\` and \`n_permutations: int\` fields. \`None\` preserves the pre-existing schema when permutations are skipped.
- \`roi_summary\` surfaces two new columns per modality when p-values are present: \`p_<m>_median\` and \`frac_sig_<m>\` (at alpha=0.05). The columns are absent (not NaN) when no permutation test was run, so downstream tables don't need to feature-flag around the new option.
- \`experiments/causal_modality_ablation.py\` gains \`--permutations\` and \`--permutation-seed\` flags. Per-subject p-value arrays land in the existing \`subject_XX_lesion.npz\` under \`p_<m>\` keys, and the top-level summary picks up \`n_permutations\`, \`p_value_medians\`, and \`frac_sig_at_05\` per modality.

## Why row-permute only the target modality's slice?

Permuting \`Y_test\` wholesale tests a weaker null (\"nothing in the model predicts anything\"). We want the per-modality null (\"modality m specifically is uninformative at test time\") so the test isolates each modality's contribution to \`delta_R^2\`. This matches the standard construction in Lahner 2024 and Conwell 2022.

## Test plan

- [x] \`python -m pytest tests/test_lesion.py -v\` -> 15 passed, 1 skipped (CUDA)
- [x] \`python -m pytest tests/ -q\` -> 238 passed, 3 skipped (no regressions)
- [x] 7 new tests: true-signal voxels yield small p (>50% significant), non-driving modalities don't inflate FP rate on noise voxels, \`n_permutations=0\` keeps \`p_values=None\`, permutation seed is reproducible (same seed -> same output, different seed -> different), p-values respect the \`[1/(B+1), 1]\` floor/ceiling, \`roi_summary\` adds/omits \`p_<m>_median\` correctly
- [x] End-to-end \`--mock\` run with \`--permutations 20\` logs median p per modality and writes per-subject \`p_<m>\` arrays to the npz
- [ ] Real run on Jarvis with \`--permutations 1000\` on one subject + one modality to budget wall-time before fanning out

## Impact on Draft 3 / paper

Any ROI row that now has \`p_<m>_median < 0.05\` is publishable as a causally-significant modality dependency with a permutation-test justification. Previously only effect sizes could be reported. Slot this directly into the Draft 3 lesion table.

---
_Original PR #48 was auto-closed when its stacked base branch was deleted after merging #46 and #49 (successor to #47). This is the same branch rebased onto master._