### PR TITLE
Add example for score_model docstring (part of #37)

### DIFF
--- a/src/cortexlab/analysis/brain_alignment.py
+++ b/src/cortexlab/analysis/brain_alignment.py
@@ -186,6 +186,16 @@ class BrainAlignmentBenchmark:
         Returns
         -------
         AlignmentResult
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from cortexlab.analysis import BrainAlignmentBenchmark
+        >>> brain_pred = np.random.randn(50, 200)
+        >>> model_feat = np.random.randn(50, 512)
+        >>> bench = BrainAlignmentBenchmark(brain_pred)
+        >>> result = bench.score_model(model_feat, method="rsa")
+        >>> result is not None
+        True
         """
         if method not in _METHODS:
             raise ValueError(f"Unknown method {method!r}. Choose from {list(_METHODS)}")


### PR DESCRIPTION
## Summary

Adds an Examples section to the `BrainAlignmentBenchmark.score_model` docstring to demonstrate typical API usage.

## Changes

* Added runnable usage example in NumPy-style docstring format
* Demonstrates creating benchmark inputs and calling `score_model`

## Testing

* Attempted local pytest run, but test suite requires missing dependency (`neuralset`)
* Verified docstring formatting manually

## Related Issues

Closes #37
