### PR TITLE
Update x_transformers to address autocast deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "torch>=2.5.1,<2.7",
   "numpy>=2.0",
   "torchvision>=0.20,<0.22",
-  "x_transformers==1.27.20",
+  "x_transformers==1.43.0",
   "einops",
   "pyyaml",
   "moviepy>=2.2.1",

--- a/src/cortexlab/analysis/brain_alignment.py
+++ b/src/cortexlab/analysis/brain_alignment.py
@@ -186,6 +186,16 @@ class BrainAlignmentBenchmark:
         Returns
         -------
         AlignmentResult
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from cortexlab.analysis import BrainAlignmentBenchmark
+        >>> brain_pred = np.random.randn(50, 200)
+        >>> model_feat = np.random.randn(50, 512)
+        >>> bench = BrainAlignmentBenchmark(brain_pred)
+        >>> result = bench.score_model(model_feat, method="rsa")
+        >>> result is not None
+        True
         """
         if method not in _METHODS:
             raise ValueError(f"Unknown method {method!r}. Choose from {list(_METHODS)}")


### PR DESCRIPTION
## Summary

Updates `x_transformers` from 1.27.20 to 1.43.0 to address deprecated `torch.cuda.amp.autocast` warnings.

## Changes

* Updated dependency pin in `pyproject.toml`
* Verified upgraded package installs and imports successfully

## Notes

This follows Option A proposed in issue #31.

## Related Issues

Closes #31
