### PR TITLE
fix(data): noise-ceiling filename template matches BOLD Moments release

### DIFF
--- a/experiments/causal_modality_ablation.py
+++ b/experiments/causal_modality_ablation.py
@@ -114,6 +114,9 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--noise-ceiling-split", type=str, default="test",
                     choices=["train", "test"],
                     help="Which split's on-disk ceiling to load from BOLD Moments.")
+    ap.add_argument("--noise-ceiling-space", type=str, default="fsaverage",
+                    help="Coordinate space for the BOLD Moments on-disk "
+                         "ceiling filename ('fsaverage', 'MNI152NLin2009cAsym', etc).")
     ap.add_argument("--permutations", type=int, default=0,
                     help="If >0, run a row-permutation test per modality with "
                          "this many shuffles; p-values land in roi_summary "
@@ -338,10 +341,11 @@ def run_study(
         from cortexlab.data.studies.lahner2024bold import load_noise_ceiling  # lazy
         nc_split = cfg.get("noise_ceiling_split") or "test"
         nc_n = int(cfg.get("noise_ceiling_n") or 10)
+        nc_space = cfg.get("noise_ceiling_space") or "fsaverage"
         for sid in subject_ids:
             ondisk_ceilings[sid] = load_noise_ceiling(
                 subject_id=sid, root=cfg.get("data_root"),
-                split=nc_split, n=nc_n,
+                split=nc_split, n=nc_n, space=nc_space,
             )
 
     for sid in subject_ids:
@@ -461,6 +465,8 @@ def main() -> None:
         cfg["noise_ceiling_n"] = args.noise_ceiling_n
     if args.noise_ceiling_split:
         cfg["noise_ceiling_split"] = args.noise_ceiling_split
+    if args.noise_ceiling_space:
+        cfg["noise_ceiling_space"] = args.noise_ceiling_space
     if args.parcellation_rois:
         cfg["parcellation_rois"] = [
             r.strip() for r in args.parcellation_rois.split(",") if r.strip()

--- a/src/cortexlab/data/studies/lahner2024bold.py
+++ b/src/cortexlab/data/studies/lahner2024bold.py
@@ -475,11 +475,13 @@ def load_subject(
 
 
 NOISE_CEILING_FILENAME_TEMPLATE: tp.Final[str] = (
-    "sub-{subject_id:02d}_organized_noiseceiling_task-{split}_hemi-{hemi}_n-{n}.pkl"
+    "sub-{subject_id:02d}_noiseceiling_space-{space}_task-{split}_hemi-{hemi}_n-{n}.pkl"
 )
 """Filename convention used by the BOLD Moments authors for pre-computed
 noise ceilings, as shipped under ``prepared_betas/`` alongside the betas.
-Both the ``n-10`` (all subjects) and ``n-k`` (subset) variants follow this
+The ``space`` slot is populated with whichever space the ceiling was
+computed in (``fsaverage``, ``MNI152NLin2009cAsym``, ...). Both the
+``n-10`` (all subjects) and ``n-k`` (subset) variants follow this
 template."""
 
 
@@ -488,6 +490,7 @@ def load_noise_ceiling(
     root: str | os.PathLike | None = None,
     split: str = "test",
     n: int = 10,
+    space: str = "fsaverage",
 ) -> np.ndarray:
     """Load the BOLD Moments on-disk noise ceiling for one subject.
 
@@ -514,7 +517,14 @@ def load_noise_ceiling(
         repetitions make the ceiling estimator robust.
     n
         The ``n`` suffix in the filename (subjects used to build the
-        ceiling). BOLD Moments ships ``n=10``.
+        ceiling). BOLD Moments ships ``n=10`` and ``n=1``; the ``test``
+        split also ships ``n=3`` for the training data.
+    space
+        Coordinate space the ceiling lives in. ``"fsaverage"`` for the
+        cortical-surface release used by :func:`load_subject`;
+        ``"MNI152NLin2009cAsym"`` (or similar) for volumetric variants
+        if the user has those staged. The same template is used; only
+        the ``space-`` slot in the filename changes.
 
     Returns
     -------
@@ -550,13 +560,14 @@ def load_noise_ceiling(
     hemi_arrays: list[np.ndarray] = []
     for hemi in ("left", "right"):
         fname = NOISE_CEILING_FILENAME_TEMPLATE.format(
-            subject_id=subject_id, split=split, hemi=hemi, n=n,
+            subject_id=subject_id, split=split, hemi=hemi, n=n, space=space,
         )
         fp = betas_root / fname
         if not fp.exists():
             raise FileNotFoundError(
                 f"missing noise-ceiling file {fp}. "
-                f"Expected the Lahner 2024 convention {NOISE_CEILING_FILENAME_TEMPLATE!r}."
+                f"Expected the Lahner 2024 convention {NOISE_CEILING_FILENAME_TEMPLATE!r} "
+                f"(space={space!r})."
             )
         with fp.open("rb") as f:
             obj = pkl.load(f)

--- a/tests/test_lahner_noise_ceiling.py
+++ b/tests/test_lahner_noise_ceiling.py
@@ -50,7 +50,7 @@ def _write_ceiling(
     sub_dir.mkdir(parents=True, exist_ok=True)
     for hemi, arr in (("left", lh), ("right", rh)):
         fp = sub_dir / NOISE_CEILING_FILENAME_TEMPLATE.format(
-            subject_id=subject_id, split=split, hemi=hemi, n=n,
+            subject_id=subject_id, split=split, hemi=hemi, n=n, space="fsaverage",
         )
         if payload_wrap == "array":
             payload = arr
@@ -117,6 +117,30 @@ def test_load_noise_ceiling_nondefault_n(tmp_path, tiny_vertices):
     assert ceiling.shape == (2 * tiny_vertices,)
 
 
+def test_load_noise_ceiling_nonfsaverage_space(tmp_path, tiny_vertices):
+    """The same template should work for volumetric variants by passing
+    ``space=`` (e.g. ``MNI152NLin2009cAsym`` for the volumetric BOLD
+    Moments release)."""
+    lh = np.full(tiny_vertices, 0.2, dtype=np.float32)
+    rh = np.full(tiny_vertices, 0.3, dtype=np.float32)
+    sub_dir = tmp_path / BETAS_SUBPATH / "sub-01" / "prepared_betas"
+    sub_dir.mkdir(parents=True, exist_ok=True)
+    for hemi, arr in (("left", lh), ("right", rh)):
+        fp = sub_dir / NOISE_CEILING_FILENAME_TEMPLATE.format(
+            subject_id=1, split="test", hemi=hemi, n=10,
+            space="MNI152NLin2009cAsym",
+        )
+        with fp.open("wb") as f:
+            pkl.dump(arr, f)
+    ceiling = load_noise_ceiling(
+        subject_id=1, root=tmp_path, n=10, space="MNI152NLin2009cAsym",
+    )
+    assert ceiling.shape == (2 * tiny_vertices,)
+    # Default space="fsaverage" should now fail because we wrote the MNI variant.
+    with pytest.raises(FileNotFoundError, match="noise-ceiling"):
+        load_noise_ceiling(subject_id=1, root=tmp_path, n=10)
+
+
 # --------------------------------------------------------------------------- #
 # error paths                                                                 #
 # --------------------------------------------------------------------------- #
@@ -139,7 +163,7 @@ def test_load_noise_ceiling_missing_hemisphere_file(tmp_path, tiny_vertices):
     fp_rh = (
         tmp_path / BETAS_SUBPATH / "sub-01" / "prepared_betas"
         / NOISE_CEILING_FILENAME_TEMPLATE.format(
-            subject_id=1, split="test", hemi="right", n=10,
+            subject_id=1, split="test", hemi="right", n=10, space="fsaverage",
         )
     )
     fp_rh.unlink()
@@ -160,7 +184,7 @@ def test_load_noise_ceiling_unknown_payload_type(tmp_path, tiny_vertices):
     sub_dir.mkdir(parents=True, exist_ok=True)
     for hemi in ("left", "right"):
         fp = sub_dir / NOISE_CEILING_FILENAME_TEMPLATE.format(
-            subject_id=1, split="test", hemi=hemi, n=10,
+            subject_id=1, split="test", hemi=hemi, n=10, space="fsaverage",
         )
         with fp.open("wb") as f:
             pkl.dump({"oops": "dict"}, f)     # neither array nor tuple


### PR DESCRIPTION
## Summary

The on-disk noise ceilings shipped with BOLD Moments use the filename pattern \`sub-XX_noiseceiling_space-{space}_task-{split}_hemi-{hemi}_n-{n}.pkl\`, not the \`organized_noiseceiling_...\` form we'd guessed. Confirmed against the user's staged data:

\`\`\`
$ ls .../sub-01/prepared_betas/ | grep noiseceiling
sub-01_noiseceiling_space-fsaverage_task-test_hemi-left_n-10.pkl
sub-01_noiseceiling_space-fsaverage_task-test_hemi-left_n-1.pkl
sub-01_noiseceiling_space-fsaverage_task-test_hemi-right_n-10.pkl
...
\`\`\`

\`load_noise_ceiling\` was hitting \`FileNotFoundError\` for every subject when called from the orchestrator's \`--noise-ceiling bold-moments\` path.

## Changes

- \`NOISE_CEILING_FILENAME_TEMPLATE\` now uses \`space-{space}\` so it matches the released convention. Same template covers fsaverage and the volumetric MNI variant; the only difference is the \`{space}\` slot.
- \`load_noise_ceiling\` grows a \`space=\"fsaverage\"\` kwarg.
- Orchestrator (\`experiments.causal_modality_ablation\`) gains a \`--noise-ceiling-space\` flag (default \`fsaverage\`) and threads it through.
- Tests updated to pass \`space=\"fsaverage\"\` in their template formatting; a new test \`test_load_noise_ceiling_nonfsaverage_space\` covers a volumetric variant and asserts the default-fsaverage lookup correctly fails when only the MNI files are present.

## Test plan

- [x] \`python -m pytest tests/test_lahner_noise_ceiling.py -v\` -> 12 passed
- [x] \`python -m pytest tests/ -q\` -> 239 passed, 3 skipped (one new test, no regressions)
- [ ] On Jarvis: rerun lesion orchestrator with \`--noise-ceiling bold-moments\` and verify the canonical n=10 ceiling loads cleanly across all 10 subjects