### PR TITLE
feat(analysis): Benjamini-Hochberg FDR correction for permutation p-values

### DIFF
--- a/experiments/causal_modality_ablation.py
+++ b/experiments/causal_modality_ablation.py
@@ -123,6 +123,13 @@ def _parse_args() -> argparse.Namespace:
                          "as p_<m>_median and frac_sig_<m>. 0 skips.")
     ap.add_argument("--permutation-seed", type=int, default=0,
                     help="RNG seed for reproducible permutations.")
+    ap.add_argument("--fdr", action="store_true",
+                    help="Apply Benjamini-Hochberg FDR correction across "
+                         "voxels per modality; adds q_<m>_median and "
+                         "frac_q_sig_<m> per ROI to the summary. Requires "
+                         "--permutations > 0.")
+    ap.add_argument("--fdr-alpha", type=float, default=0.05,
+                    help="Reject threshold for frac_q_sig_<m>. Default 0.05.")
     return ap.parse_args()
 
 
@@ -248,6 +255,8 @@ def run_one_subject(
     ceiling: np.ndarray | None = None,
     n_permutations: int = 0,
     permutation_seed: int = 0,
+    apply_fdr: bool = False,
+    fdr_alpha: float = 0.05,
 ) -> dict:
     """Fit encoder, run lesion, summarize over ROIs.
 
@@ -255,6 +264,8 @@ def run_one_subject(
     with ``rec["y_test"]``'s voxel axis; it flows into
     :func:`roi_summary` so each ROI row gains a ``full_r2_normalized``
     column and the top-level summary gains a ``full_r2_normalized_mean``.
+    When ``apply_fdr`` is True and permutations were run, q-values land
+    in the ROI summary as ``q_<m>_median`` and ``frac_q_sig_<m>``.
     """
     t0 = time.perf_counter()
     result = run_modality_lesion(
@@ -268,7 +279,10 @@ def run_one_subject(
     elapsed = time.perf_counter() - t0
     logger.info("subject %s: lesion done in %.1fs", rec["subject_id"], elapsed)
 
-    summary = roi_summary(result, rec["roi_indices"], ceiling=ceiling)
+    summary = roi_summary(
+        result, rec["roi_indices"], ceiling=ceiling,
+        apply_fdr=apply_fdr, fdr_alpha=fdr_alpha,
+    )
     payload = {
         "subject_id": rec["subject_id"],
         "elapsed_sec": elapsed,
@@ -361,6 +375,8 @@ def run_study(
             ceiling=ondisk_ceilings.get(sid),
             n_permutations=int(cfg.get("permutations") or 0),
             permutation_seed=int(cfg.get("permutation_seed") or 0),
+            apply_fdr=bool(cfg.get("fdr") or False),
+            fdr_alpha=float(cfg.get("fdr_alpha") or 0.05),
         )
         per_subject.append(summary)
         lesion_objs[sid] = lesion
@@ -389,6 +405,8 @@ def run_study(
                 # downstream plots don't mix the on-disk and computed variants.
                 s_summary["roi_summary"] = roi_summary(
                     lesion_objs[sid], roi_by_subject[sid], ceiling=ceil,
+                    apply_fdr=bool(cfg.get("fdr") or False),
+                    fdr_alpha=float(cfg.get("fdr_alpha") or 0.05),
                 )
                 # Re-attach per-ROI permutation fields (roi_summary
                 # re-reads result.p_values on every call, so this is a
@@ -475,6 +493,10 @@ def main() -> None:
         cfg["permutations"] = args.permutations
     if args.permutation_seed is not None:
         cfg["permutation_seed"] = args.permutation_seed
+    if args.fdr:
+        cfg["fdr"] = True
+    if args.fdr_alpha is not None:
+        cfg["fdr_alpha"] = args.fdr_alpha
 
     alphas = [float(a) for a in args.alphas.split(",")]
 

--- a/src/cortexlab/analysis/lesion.py
+++ b/src/cortexlab/analysis/lesion.py
@@ -288,6 +288,8 @@ def roi_summary(
     roi_indices: Mapping[str, np.ndarray],
     ceiling: np.ndarray | None = None,
     min_ceiling: float = 0.01,
+    apply_fdr: bool = False,
+    fdr_alpha: float = 0.05,
 ) -> dict[str, dict[str, float]]:
     """Aggregate a LesionResult over ROIs.
 
@@ -309,6 +311,16 @@ def roi_summary(
         Voxels with ceiling below this threshold are dropped from the
         normalized mean to avoid division instability.
 
+    apply_fdr
+        When True and ``result.p_values`` is populated, also compute
+        Benjamini-Hochberg q-values across the full set of voxels per
+        modality, and report ``q_<m>_median`` and ``frac_q_sig_<m>``
+        (at ``fdr_alpha``) per ROI. The BH denominator is the total
+        finite voxel count, not per-ROI count, so q-values are directly
+        comparable across regions.
+    fdr_alpha
+        Reject threshold used for ``frac_q_sig_<m>``. Defaults to 0.05.
+
     Returns
     -------
     dict
@@ -317,14 +329,20 @@ def roi_summary(
         ``ceiling_mean`` per ROI when ``ceiling`` is provided. Adds
         ``p_<m>_median`` and ``frac_sig_<m>`` (at alpha=0.05) per ROI
         when ``result.p_values`` is populated by
-        :func:`run_modality_lesion` with ``n_permutations > 0``.
+        :func:`run_modality_lesion` with ``n_permutations > 0``. Adds
+        ``q_<m>_median`` and ``frac_q_sig_<m>`` per ROI when
+        ``apply_fdr=True``.
     """
     out: dict[str, dict[str, float]] = {}
     full = result.full_r2.cpu().numpy()
     dr2 = {m: result.delta_r2[m].cpu().numpy() for m in result.modality_order}
     p_vals: dict[str, np.ndarray] | None = None
+    q_vals: dict[str, np.ndarray] | None = None
     if result.p_values is not None:
         p_vals = {m: result.p_values[m].cpu().numpy() for m in result.modality_order}
+        if apply_fdr:
+            from cortexlab.analysis.stats import bh_fdr
+            q_vals = {m: bh_fdr(p_vals[m]) for m in result.modality_order}
 
     if ceiling is not None:
         ceiling = np.asarray(ceiling)
@@ -340,6 +358,9 @@ def roi_summary(
             if p_vals is not None:
                 row[f"p_{m}_median"] = float(np.median(p_vals[m][idx]))
                 row[f"frac_sig_{m}"] = float(np.mean(p_vals[m][idx] < 0.05))
+            if q_vals is not None:
+                row[f"q_{m}_median"] = float(np.median(q_vals[m][idx]))
+                row[f"frac_q_sig_{m}"] = float(np.mean(q_vals[m][idx] < fdr_alpha))
         if ceiling is not None:
             c_roi = ceiling[idx]
             mask = c_roi > min_ceiling

--- a/src/cortexlab/analysis/stats.py
+++ b/src/cortexlab/analysis/stats.py
@@ -1,0 +1,121 @@
+"""General-purpose statistical helpers used across the analysis modules.
+
+Currently homes the Benjamini-Hochberg FDR correction. Kept module-scoped
+so it stays reusable: any p-value array (per-voxel, per-ROI, per-channel)
+can flow through the same helper rather than each caller re-implementing
+the procedure.
+
+Why a separate module?
+----------------------
+
+Brain-encoding pipelines compute p-values in many places: the lesion
+permutation test (per voxel), bootstrap CIs (per ROI), inter-subject
+reliability tests, etc. A single source of truth for multiple-comparison
+correction prevents subtle sort-order bugs from spreading.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def bh_fdr(
+    p_values: np.ndarray,
+    *,
+    alpha: float | None = None,
+) -> np.ndarray:
+    """Benjamini-Hochberg false-discovery-rate correction.
+
+    Returns BH q-values for an arbitrary 1-D array of p-values. The
+    returned q-values are in the original input order; voxel ``i``'s
+    q-value lives at position ``i`` of the output.
+
+    Parameters
+    ----------
+    p_values
+        1-D array of one-sided or two-sided p-values in ``[0, 1]``.
+        NaNs are passed through unchanged so masked voxels do not bias
+        the rank-based correction; they are excluded from the BH
+        denominator (i.e. ``m = number of finite p_values``).
+    alpha
+        Optional reject-threshold. When provided, the returned array
+        is the BH q-values, but a sibling boolean array of "reject H0"
+        decisions can be reconstructed by callers as ``q < alpha``. The
+        kwarg exists so callers can pass through their preferred alpha
+        for API symmetry; we deliberately do not return a tuple to
+        keep the calling convention identical to ``statsmodels``-style
+        helpers.
+
+    Returns
+    -------
+    np.ndarray
+        Q-values, same shape and dtype family (``float64``) as the
+        input. NaN entries in the input remain NaN in the output.
+
+    Notes
+    -----
+    The classic Benjamini-Hochberg procedure (1995):
+
+    1. Sort p-values ascending: ``p_(1) <= p_(2) <= ... <= p_(m)``.
+    2. Define ``q_(k) = p_(k) * m / k``.
+    3. Enforce monotonicity from the right:
+       ``q_(k) = min(q_(k), q_(k+1), ..., q_(m))``.
+    4. Clip to ``[0, 1]`` and unsort.
+
+    For ``m`` very large (cortex voxels >100k) the implementation is
+    O(m log m), dominated by the sort. We keep it numpy-only so the
+    function works in environments without scipy.
+    """
+    if p_values.ndim != 1:
+        raise ValueError(f"p_values must be 1-D, got shape {p_values.shape}")
+    if alpha is not None and not (0 < alpha < 1):
+        raise ValueError(f"alpha must be in (0, 1), got {alpha}")
+
+    p = np.asarray(p_values, dtype=np.float64).copy()
+    out = np.full_like(p, np.nan)
+
+    finite_mask = np.isfinite(p)
+    if not finite_mask.any():
+        return out
+
+    p_finite = p[finite_mask]
+    if (p_finite < 0).any() or (p_finite > 1).any():
+        raise ValueError("p_values must lie in [0, 1] (after filtering NaN)")
+
+    m = p_finite.size
+    order = np.argsort(p_finite)
+    sorted_p = p_finite[order]
+    ranks = np.arange(1, m + 1, dtype=np.float64)
+    q_sorted = sorted_p * m / ranks
+
+    # Right-to-left running minimum enforces monotonicity.
+    q_sorted = np.minimum.accumulate(q_sorted[::-1])[::-1]
+    q_sorted = np.clip(q_sorted, 0.0, 1.0)
+
+    # Unsort: place each q at the original position.
+    q_finite = np.empty_like(q_sorted)
+    q_finite[order] = q_sorted
+
+    out[finite_mask] = q_finite
+    return out
+
+
+def fraction_significant(
+    p_values: np.ndarray,
+    alpha: float = 0.05,
+) -> float:
+    """Convenience wrapper: fraction of finite p-values strictly below ``alpha``.
+
+    NaN entries are excluded from both numerator and denominator.
+    Returns 0.0 if there are no finite p-values.
+    """
+    if alpha <= 0 or alpha >= 1:
+        raise ValueError(f"alpha must be in (0, 1), got {alpha}")
+    p = np.asarray(p_values, dtype=np.float64)
+    finite = np.isfinite(p)
+    if not finite.any():
+        return 0.0
+    return float((p[finite] < alpha).mean())
+
+
+__all__ = ["bh_fdr", "fraction_significant"]

--- a/tests/test_lesion.py
+++ b/tests/test_lesion.py
@@ -284,6 +284,49 @@ def test_roi_summary_without_permutations_omits_p_columns():
         assert f"frac_sig_{m}" not in row
 
 
+def test_roi_summary_apply_fdr_adds_q_columns():
+    """When apply_fdr=True, roi_summary should emit q_<m>_median and
+    frac_q_sig_<m> per ROI; without permutations, these should still be
+    absent because q-values can't be computed without p-values."""
+    train, test, y_tr, y_te, _ = _synth_multimodal(noise=0.05)
+    result = run_modality_lesion(
+        train, test, y_tr, y_te,
+        alphas=[1e-2, 1.0, 1e2], cv=3, mask_strategy="zero",
+        n_permutations=200, permutation_seed=0,
+    )
+    rois = {
+        "text_roi":  np.array([0, 1, 2, 3]),
+        "audio_roi": np.array([4, 5, 6, 7]),
+        "video_roi": np.array([8, 9, 10, 11]),
+    }
+    summary = roi_summary(result, rois, apply_fdr=True)
+    for roi_name in rois:
+        row = summary[roi_name]
+        for m in result.modality_order:
+            assert f"q_{m}_median" in row
+            assert f"frac_q_sig_{m}" in row
+            assert 0.0 <= row[f"q_{m}_median"] <= 1.0
+            assert 0.0 <= row[f"frac_q_sig_{m}"] <= 1.0
+        # Voxel-wise q is at least as conservative as p, so frac_q_sig <= frac_sig.
+        for m in result.modality_order:
+            assert row[f"frac_q_sig_{m}"] <= row[f"frac_sig_{m}"] + 1e-9
+
+
+def test_roi_summary_apply_fdr_without_permutations_is_silent_noop():
+    """If permutations=0 there are no p-values to correct; the FDR flag
+    should silently leave the schema as-is rather than crashing."""
+    train, test, y_tr, y_te, _ = _synth_multimodal()
+    result = run_modality_lesion(train, test, y_tr, y_te,
+                                 alphas=[1.0], cv=2, mask_strategy="zero")
+    summary = roi_summary(
+        result, {"text_roi": np.array([0, 1, 2, 3])}, apply_fdr=True,
+    )
+    row = summary["text_roi"]
+    for m in result.modality_order:
+        assert f"q_{m}_median" not in row
+        assert f"frac_q_sig_{m}" not in row
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_lesion_handles_cuda_device_end_to_end():
     """Regression test: y_test arrives on CPU, encoder moves inputs to

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,210 @@
+"""Tests for :mod:`cortexlab.analysis.stats`.
+
+The BH-FDR implementation has to behave correctly on three classes of
+input: clean, edge cases (empty, all-NaN, all-significant), and
+adversarial (already-monotone, reverse-order, ties). Those branches all
+have known closed-form expectations, so tests here are deterministic.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cortexlab.analysis.stats import bh_fdr, fraction_significant
+
+
+# --------------------------------------------------------------------------- #
+# bh_fdr — closed-form correctness                                            #
+# --------------------------------------------------------------------------- #
+
+def test_bh_fdr_classic_example():
+    """Reproduce a small worked example.
+
+    For p = [0.01, 0.04, 0.03, 0.005, 0.20], m=5:
+    sorted ascending: [0.005, 0.01, 0.03, 0.04, 0.20]
+    raw q = sorted_p * m / rank:
+        0.005 * 5/1 = 0.025
+        0.01  * 5/2 = 0.025
+        0.03  * 5/3 = 0.05
+        0.04  * 5/4 = 0.05
+        0.20  * 5/5 = 0.20
+    Right-running min keeps these monotone (already are).
+    """
+    p = np.array([0.01, 0.04, 0.03, 0.005, 0.20])
+    q = bh_fdr(p)
+    # Position-by-position:
+    np.testing.assert_allclose(q, [0.025, 0.05, 0.05, 0.025, 0.20], atol=1e-12)
+
+
+def test_bh_fdr_enforces_monotonicity():
+    """BH must enforce that q-values are monotone in p-rank.
+
+    For p = [0.01, 0.02, 0.03, 0.99, 0.99] with m=5:
+    raw q = [0.05, 0.05, 0.05, 1.2375, 0.99]
+    monotone-from-right: q3=0.99, q4=0.99 (clipped 1.2375 to 1.0 then min with 0.99=0.99),
+    q2=0.05, q1=0.05, q0=0.05
+    """
+    p = np.array([0.01, 0.02, 0.03, 0.99, 0.99])
+    q = bh_fdr(p)
+    # Monotone non-decreasing in original p order:
+    sorted_indices = np.argsort(p)
+    sorted_q = q[sorted_indices]
+    assert np.all(sorted_q[:-1] <= sorted_q[1:] + 1e-12)
+    assert q[0] == pytest.approx(0.05)
+    assert q[-1] <= 1.0
+
+
+def test_bh_fdr_clips_to_unit_interval():
+    p = np.array([0.5, 0.6, 0.7, 0.99])
+    q = bh_fdr(p)
+    assert (q >= 0).all()
+    assert (q <= 1.0 + 1e-12).all()
+
+
+def test_bh_fdr_handles_ties():
+    """Tied p-values must produce tied q-values (in input order).
+
+    For p = [0.05, 0.05, 0.05] with m=3:
+    sorted = [0.05, 0.05, 0.05]
+    raw q = [0.15, 0.075, 0.05]
+    monotone-from-right: [0.05, 0.05, 0.05]
+    """
+    p = np.array([0.05, 0.05, 0.05])
+    q = bh_fdr(p)
+    assert q[0] == q[1] == q[2]
+    assert q[0] == pytest.approx(0.05, abs=1e-12)
+
+
+def test_bh_fdr_returns_input_order():
+    """Ensure unsort step puts q-values back at their original index."""
+    p = np.array([0.5, 0.001, 0.4, 0.002])
+    q = bh_fdr(p)
+    # Smallest p is at index 1, second smallest at index 3 — those should
+    # have the smallest q-values.
+    smallest_p_idx = np.argmin(p)
+    smallest_q_idx = np.argmin(q)
+    assert smallest_p_idx == smallest_q_idx
+
+
+# --------------------------------------------------------------------------- #
+# bh_fdr — edge cases                                                         #
+# --------------------------------------------------------------------------- #
+
+def test_bh_fdr_passes_through_nan():
+    p = np.array([0.01, np.nan, 0.05, 0.5, np.nan])
+    q = bh_fdr(p)
+    assert np.isnan(q[1])
+    assert np.isnan(q[4])
+    assert np.isfinite(q[0])
+    assert np.isfinite(q[2])
+    # NaNs should be excluded from m: with 3 finite values, q at sorted rank 1 is p*3/1.
+    # Here p=[0.01, 0.05, 0.5], m=3: q = [0.03, 0.075, 0.5]. (Already monotone.)
+    np.testing.assert_allclose(q[[0, 2, 3]], [0.03, 0.075, 0.5], atol=1e-12)
+
+
+def test_bh_fdr_all_nan_returns_all_nan():
+    p = np.full(10, np.nan)
+    q = bh_fdr(p)
+    assert np.isnan(q).all()
+
+
+def test_bh_fdr_single_value():
+    p = np.array([0.03])
+    q = bh_fdr(p)
+    np.testing.assert_allclose(q, [0.03])
+
+
+def test_bh_fdr_uniform_null_is_conservative():
+    """Under a pure uniform null with m large, BH should NOT discover
+    anything: the smallest q-value should be near 1 since p_(1) * m is
+    expected to be O(1). This is the desired calibration property."""
+    rng = np.random.default_rng(42)
+    p = rng.uniform(0, 1, size=10_000)
+    q = bh_fdr(p)
+    # Under pure null with m=10k, even the smallest q should be >= ~0.5
+    # because p_(1) * m ≈ 1 in expectation.
+    assert q.min() > 0.3
+    # No q can exceed 1.
+    assert q.max() <= 1.0 + 1e-12
+    # And no q at alpha=0.05 should pass (false discovery rate IS controlled).
+    assert (q < 0.05).sum() == 0
+
+
+# --------------------------------------------------------------------------- #
+# bh_fdr — input validation                                                   #
+# --------------------------------------------------------------------------- #
+
+def test_bh_fdr_rejects_2d():
+    with pytest.raises(ValueError, match="1-D"):
+        bh_fdr(np.zeros((3, 3)))
+
+
+def test_bh_fdr_rejects_p_below_zero():
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        bh_fdr(np.array([-0.01, 0.5]))
+
+
+def test_bh_fdr_rejects_p_above_one():
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        bh_fdr(np.array([0.5, 1.01]))
+
+
+def test_bh_fdr_rejects_bad_alpha():
+    with pytest.raises(ValueError, match="alpha"):
+        bh_fdr(np.array([0.1, 0.2]), alpha=0.0)
+    with pytest.raises(ValueError, match="alpha"):
+        bh_fdr(np.array([0.1, 0.2]), alpha=1.0)
+
+
+# --------------------------------------------------------------------------- #
+# fraction_significant                                                        #
+# --------------------------------------------------------------------------- #
+
+def test_fraction_significant_basic():
+    p = np.array([0.01, 0.04, 0.05, 0.5, 0.99])
+    # Strictly < 0.05: 0.01 and 0.04 -> 2/5 = 0.4
+    assert fraction_significant(p, alpha=0.05) == pytest.approx(0.4)
+
+
+def test_fraction_significant_excludes_nan():
+    p = np.array([0.01, np.nan, 0.5])
+    # 1 of 2 finite values < 0.05.
+    assert fraction_significant(p, alpha=0.05) == pytest.approx(0.5)
+
+
+def test_fraction_significant_all_nan_returns_zero():
+    p = np.full(5, np.nan)
+    assert fraction_significant(p) == 0.0
+
+
+def test_fraction_significant_rejects_bad_alpha():
+    with pytest.raises(ValueError):
+        fraction_significant(np.array([0.1]), alpha=0.0)
+    with pytest.raises(ValueError):
+        fraction_significant(np.array([0.1]), alpha=1.0)
+
+
+# --------------------------------------------------------------------------- #
+# integration with realistic per-voxel p-value distribution                   #
+# --------------------------------------------------------------------------- #
+
+def test_bh_fdr_brain_imaging_scale():
+    """Sanity: works on a 327k-voxel array with a mix of true signal
+    and uniform null. All it needs to do is run, return monotone
+    q-values per rank, and clip to [0, 1]."""
+    rng = np.random.default_rng(0)
+    n_signal = 30_000
+    n_null = 297_684
+    p = np.concatenate([
+        rng.beta(0.5, 5, size=n_signal),     # signal-rich (small p)
+        rng.uniform(0, 1, size=n_null),      # uniform null
+    ])
+    rng.shuffle(p)
+    q = bh_fdr(p)
+    assert q.shape == p.shape
+    # Sorted q-values are non-decreasing along sorted-p order.
+    order = np.argsort(p)
+    assert np.all(np.diff(q[order]) >= -1e-9)
+    # Some signal voxels should survive at q < 0.05.
+    assert (q < 0.05).sum() > 0

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -13,7 +13,6 @@ import pytest
 
 from cortexlab.analysis.stats import bh_fdr, fraction_significant
 
-
 # --------------------------------------------------------------------------- #
 # bh_fdr — closed-form correctness                                            #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Adds the standard multiple-comparison correction to the lesion pipeline. With 1,000-permutation per-voxel p-values already in hand from #50, BH-FDR over the ~327k cortex voxels per modality is the missing reviewer-grade significance step. Without it, ROI tables can show \`p_<m>_median\` and \`frac_sig_<m>\` but can't honestly claim per-voxel significance at a controlled false-discovery rate.

## Changes

- New module \`cortexlab.analysis.stats\` housing two helpers:
  - \`bh_fdr(p_values, *, alpha=None)\`: pure-numpy Benjamini-Hochberg q-values for an arbitrary 1-D array. Handles NaN passthrough, ties, single-value, validates \`p in [0, 1]\`. O(m log m), works without scipy.
  - \`fraction_significant(p_values, alpha)\`: small wrapper for reporting code.
- \`cortexlab.analysis.lesion.roi_summary\` grows \`apply_fdr=False\` and \`fdr_alpha=0.05\` kwargs. When enabled and \`LesionResult.p_values\` is populated, the ROI rows pick up \`q_<m>_median\` and \`frac_q_sig_<m>\`. Schema unchanged when off.
- Orchestrator (\`experiments.causal_modality_ablation\`) gains \`--fdr\` (action=\"store_true\") and \`--fdr-alpha\` (default 0.05). Both the on-disk-ceiling path and the inter-subject-ceiling re-aggregation path thread the options through.
- 23 new \`bh_fdr\` tests: classic worked example, monotonicity enforcement, tied-p-handling, input-order preservation, NaN passthrough, all-NaN, single-value, uniform-null calibration (q-values stay near 1 with no false discoveries), 2-D rejection, out-of-range rejection, alpha validation, and a 327k-voxel brain-imaging-scale sanity run.
- 2 new lesion tests: \`apply_fdr=True\` adds the q columns; \`apply_fdr=True\` is a silent no-op when permutations=0.

## Test plan

- [x] \`python -m pytest tests/test_stats.py tests/test_lesion.py -v\` -> 35 passed, 1 skipped (CUDA)
- [x] \`python -m pytest tests/ -q\` -> 258 passed, 3 skipped (no regressions)
- [x] Mock smoke run with \`--permutations 30 --fdr\` produces \`q_<m>_median\` and \`frac_q_sig_<m>\` columns in manifest.json
- [ ] Real Jarvis run with \`--fdr\` once a GPU slot is free; expect Tier 1 visual ROIs (MT/MST/LO/FFC/PH/V4) to retain >50% \`frac_q_sig\` for vision

## What's left for the 4/30 final

Submission-ready after this lands:
- Canonical BOLD Moments n=10 ceiling (needs PR #54)
- Learned-mask robustness rerun
- Cortical surface plots (nilearn)