### PR TITLE
feat(viz): pluggable surface renderer; plotly + WebGL by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,16 @@ streaming = [
 analysis = [
   "scipy",
 ]
+viz = [
+  # GPU-accelerated cortical surface rendering via plotly's WebGL engine.
+  # Lets `cortexlab.viz.surface_renderer.PlotlyRenderer` produce static
+  # PNGs and animated GIFs/MP4s in seconds rather than minutes.
+  "plotly>=5.0",
+  "kaleido>=0.2",         # static PNG export from plotly figures
+  "Pillow>=9.0",          # GIF assembly
+  "imageio>=2.31",        # MP4 assembly via the imageio-ffmpeg backend
+  "imageio-ffmpeg>=0.4",
+]
 dev = [
   "pytest",
   "pytest-cov",

--- a/scripts/animate_cortical_maps.py
+++ b/scripts/animate_cortical_maps.py
@@ -173,7 +173,7 @@ def main() -> None:
             f"statmap {args.statmap} has no finite values; nothing to animate."
         )
 
-    from cortexlab.viz.surface_renderer import make_renderer, RenderConfig
+    from cortexlab.viz.surface_renderer import RenderConfig, make_renderer
     renderer = make_renderer(engine=args.engine, mesh=args.mesh)
     config = RenderConfig(
         mesh=args.mesh, cmap=args.cmap,

--- a/scripts/animate_cortical_maps.py
+++ b/scripts/animate_cortical_maps.py
@@ -1,27 +1,28 @@
-"""Render rotating-brain GIFs of cortical surface maps.
+"""Render rotating-brain GIFs/MP4s of cortical surface maps.
 
-Companion to ``scripts/plot_cortical_maps.py``: loads the same
+Companion to :mod:`scripts.plot_cortical_maps`. Loads the same
 group-mean per-vertex statistics from a lesion-study output directory,
-but renders 36 frames around the vertical axis and combines them into
-an animated GIF. Animations are the natural visualization for a 3D
-inflated cortex on a 2D slide; static views always lose information
-to occlusion.
+renders N frames around the vertical axis, and combines them into an
+animated GIF (or MP4 with ``--format mp4``). Animations are the natural
+visualization for 3D inflated cortex on a 2D slide; static views always
+lose information to occlusion at the medial wall.
 
-Output format::
+Two rendering engines:
 
-    results_dir/anim_<statmap>_<hemi>.gif
+* ``--engine plotly`` (default when ``[viz]`` extras installed): WebGL,
+  GPU-accelerated, ~30s for a 36-frame fsaverage7 GIF.
+* ``--engine matplotlib``: pure CPU, ~12 min per 36-frame GIF on
+  fsaverage5; impractical at fsaverage7.
 
 Usage
 -----
+
+::
 
     python scripts/animate_cortical_maps.py \\
         --results-dir $CORTEXLAB_RESULTS/lesion/final_YYYYMMDD_HHMMSS \\
         --statmap dr2_vision_q05 \\
         --hemi both
-
-Dependencies: ``nilearn`` and ``Pillow``. ``Pillow`` is the standard
-Python imaging library; nearly every Python install has it via
-matplotlib's transitive dependency.
 """
 
 from __future__ import annotations
@@ -32,53 +33,42 @@ import json
 import logging
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 logger = logging.getLogger(__name__)
 
 
-MESH_VERTS_PER_HEMI = {
-    "fsaverage": 163842,
-    "fsaverage7": 163842,
-    "fsaverage6": 40962,
-    "fsaverage5": 10242,
-    "fsaverage4": 2562,
-    "fsaverage3": 642,
-}
-
-
 def parse_args() -> argparse.Namespace:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--results-dir", type=Path, required=True,
-                    help="Lesion-study output directory.")
+    ap.add_argument("--results-dir", type=Path, required=True)
     ap.add_argument("--statmap", type=str, default="dr2_vision_q05",
                     choices=["full_r2",
                              "dr2_vision", "dr2_vision_q05",
-                             "dr2_text", "dr2_text_q05"],
-                    help="Which group-mean array to animate. The _q05 "
-                         "variants are masked to BH-FDR q < 0.05.")
+                             "dr2_text", "dr2_text_q05"])
     ap.add_argument("--hemi", type=str, default="both",
-                    choices=["left", "right", "both"],
-                    help="Hemisphere to spin. 'both' produces a side-by-side "
-                         "panel (LH + RH) per frame.")
+                    choices=["left", "right", "both"])
+    ap.add_argument("--engine", type=str, default="auto",
+                    choices=["auto", "matplotlib", "plotly"])
     ap.add_argument("--mesh", type=str, default="fsaverage5",
-                    choices=list(MESH_VERTS_PER_HEMI),
-                    help="fsaverage variant. fsaverage5 (default) renders "
-                         "in seconds per frame; fsaverage7 is much slower.")
+                    choices=["fsaverage", "fsaverage5", "fsaverage6",
+                             "fsaverage7"])
     ap.add_argument("--cmap", type=str, default="cold_hot")
-    ap.add_argument("--threshold", type=float, default=None,
-                    help="Hide vertices below this absolute value.")
-    ap.add_argument("--q-threshold", type=float, default=0.05,
-                    help="q-value cutoff used for the _q05 statmaps.")
+    ap.add_argument("--threshold", type=float, default=None)
+    ap.add_argument("--q-threshold", type=float, default=0.05)
     ap.add_argument("--n-frames", type=int, default=36,
-                    help="Frames around the full rotation. 36 = 10° steps.")
+                    help="36 = 10° steps for a 360° rotation.")
     ap.add_argument("--frame-duration-ms", type=int, default=80,
-                    help="Per-frame display time in the GIF (ms). 80ms = "
-                         "12.5 fps, smooth and readable.")
-    ap.add_argument("--elevation", type=float, default=0.0,
-                    help="Camera elevation in degrees (0 = horizontal).")
-    ap.add_argument("--dpi", type=int, default=120)
+                    help="Per-frame display time. 80ms = 12.5 fps.")
+    ap.add_argument("--elevation", type=float, default=0.0)
+    ap.add_argument("--dpi", type=int, default=120,
+                    help="matplotlib only.")
+    ap.add_argument("--width", type=int, default=1200,
+                    help="plotly only.")
+    ap.add_argument("--height", type=int, default=600,
+                    help="plotly only.")
+    ap.add_argument("--format", type=str, default="gif",
+                    choices=["gif", "mp4"],
+                    help="Output container. mp4 needs imageio-ffmpeg.")
     return ap.parse_args()
 
 
@@ -91,12 +81,7 @@ def _resolve_statmap(results_dir: Path, statmap: str,
                      subject_ids: list[int],
                      modalities: list[str],
                      q_threshold: float) -> np.ndarray:
-    """Load + group-mean the requested statmap from per-subject npz files.
-
-    For ``_q05`` variants, computes per-subject q-values via
-    :func:`cortexlab.analysis.stats.bh_fdr` over each subject's voxel
-    p-values, group-means the q's, and masks the corresponding ΔR² array.
-    """
+    """Load + group-mean the requested statmap from per-subject npz files."""
     full_r2: list[np.ndarray] = []
     dR2: dict[str, list[np.ndarray]] = {m: [] for m in modalities}
     p_vals: dict[str, list[np.ndarray]] = {m: [] for m in modalities}
@@ -116,9 +101,9 @@ def _resolve_statmap(results_dir: Path, statmap: str,
     if statmap == "full_r2":
         return _group_mean(full_r2)
 
-    name, *suffix = statmap.split("_")  # e.g. "dr2", ["vision", "q05"]
+    name, *suffix = statmap.split("_")  # "dr2", ["vision", "q05"]
     modality = suffix[0]
-    is_masked = suffix[-1] == "q05" if len(suffix) > 1 else False
+    is_masked = len(suffix) > 1 and suffix[-1] == "q05"
 
     delta = _group_mean(dR2[modality])
     if not is_masked:
@@ -126,8 +111,8 @@ def _resolve_statmap(results_dir: Path, statmap: str,
 
     if not p_vals[modality]:
         raise SystemExit(
-            f"statmap {statmap} requires p-value arrays in the npz files; "
-            "rerun the orchestrator with --permutations N to populate them."
+            f"statmap {statmap} requires per-subject p_{modality} arrays "
+            "in the npz; rerun the orchestrator with --permutations N."
         )
     from cortexlab.analysis.stats import bh_fdr  # lazy
     q_per_subject = [bh_fdr(p) for p in p_vals[modality]]
@@ -137,80 +122,36 @@ def _resolve_statmap(results_dir: Path, statmap: str,
     return masked
 
 
-def _truncate_to_mesh(stat_map: np.ndarray, mesh: str) -> np.ndarray:
-    """fsaverage hierarchical-subset truncation when data is higher-res."""
-    n_vert_per_hemi = MESH_VERTS_PER_HEMI[mesh]
-    n_data_per_hemi = stat_map.shape[0] // 2
-    if n_data_per_hemi == n_vert_per_hemi:
-        return stat_map
-    if n_vert_per_hemi > n_data_per_hemi:
-        raise ValueError(
-            f"data has {n_data_per_hemi} verts/hemi; cannot upsample to "
-            f"{mesh}'s {n_vert_per_hemi}."
-        )
-    lh = stat_map[:n_vert_per_hemi]
-    rh = stat_map[n_data_per_hemi : n_data_per_hemi + n_vert_per_hemi]
-    return np.concatenate([lh, rh])
+def _write_gif(frames_png: list[bytes], out_path: Path, duration_ms: int) -> None:
+    from PIL import Image  # lazy
+    pil_frames = [Image.open(io.BytesIO(b)).convert("RGB") for b in frames_png]
+    pil_frames[0].save(
+        out_path, save_all=True, append_images=pil_frames[1:],
+        duration=duration_ms, loop=0, optimize=True,
+    )
 
 
-def _render_frame(stat_map_truncated: np.ndarray, fs, hemi: str,
-                  elev: float, azim: float,
-                  cmap: str, threshold: float | None,
-                  vmin: float, vmax: float, dpi: int) -> bytes:
-    """Render one frame and return PNG bytes (in-memory)."""
-    from nilearn.plotting import plot_surf_stat_map  # lazy
-
-    n_vert_per_hemi = stat_map_truncated.shape[0] // 2
-    lh_data = stat_map_truncated[:n_vert_per_hemi]
-    rh_data = stat_map_truncated[n_vert_per_hemi:]
-
-    if hemi == "both":
-        fig, axarr = plt.subplots(
-            1, 2, figsize=(10, 5),
-            subplot_kw={"projection": "3d"},
-            gridspec_kw={"wspace": 0, "hspace": 0},
-        )
-        plot_surf_stat_map(
-            fs.infl_left, lh_data, bg_map=fs.sulc_left,
-            hemi="left", view=(elev, azim),
-            cmap=cmap, vmax=vmax, vmin=vmin, threshold=threshold,
-            colorbar=False, axes=axarr[0],
-        )
-        plot_surf_stat_map(
-            fs.infl_right, rh_data, bg_map=fs.sulc_right,
-            hemi="right", view=(elev, azim),
-            cmap=cmap, vmax=vmax, vmin=vmin, threshold=threshold,
-            colorbar=False, axes=axarr[1],
-        )
-    else:
-        fig, ax = plt.subplots(
-            figsize=(6, 6), subplot_kw={"projection": "3d"},
-        )
-        data = lh_data if hemi == "left" else rh_data
-        mesh_geom = fs.infl_left if hemi == "left" else fs.infl_right
-        sulc = fs.sulc_left if hemi == "left" else fs.sulc_right
-        plot_surf_stat_map(
-            mesh_geom, data, bg_map=sulc,
-            hemi=hemi, view=(elev, azim),
-            cmap=cmap, vmax=vmax, vmin=vmin, threshold=threshold,
-            colorbar=False, axes=ax,
-        )
-
-    buf = io.BytesIO()
-    fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight",
-                facecolor="white")
-    plt.close(fig)
-    buf.seek(0)
-    return buf.read()
+def _write_mp4(frames_png: list[bytes], out_path: Path, duration_ms: int) -> None:
+    """MP4 export via imageio-ffmpeg. Smaller than GIF, plays in PowerPoint."""
+    try:
+        import imageio.v3 as iio
+    except ImportError as e:
+        raise SystemExit(
+            "MP4 output requires imageio. Install with `pip install imageio imageio-ffmpeg`."
+        ) from e
+    from PIL import Image  # lazy
+    fps = 1000.0 / duration_ms
+    pil_frames = [
+        np.asarray(Image.open(io.BytesIO(b)).convert("RGB"))
+        for b in frames_png
+    ]
+    iio.imwrite(out_path, np.stack(pil_frames), fps=fps, codec="libx264")
 
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO,
                         format="%(asctime)s %(levelname)s %(message)s")
     args = parse_args()
-
-    from PIL import Image  # lazy
-    from nilearn.datasets import fetch_surf_fsaverage  # lazy
 
     results_dir = args.results_dir
     manifest_path = results_dir / "manifest.json"
@@ -219,48 +160,46 @@ def main() -> None:
     manifest = json.loads(manifest_path.read_text())
     modalities = manifest["results"][0]["modality_order"]
 
-    logger.info("loading %s across %d subjects", args.statmap, len(manifest["subject_ids"]))
+    logger.info("loading %s across %d subjects",
+                args.statmap, len(manifest["subject_ids"]))
     stat_map = _resolve_statmap(
         results_dir, args.statmap, manifest["subject_ids"],
         modalities, args.q_threshold,
     )
-    stat_map = _truncate_to_mesh(stat_map, args.mesh)
 
     finite = np.isfinite(stat_map)
     if not finite.any():
         raise SystemExit(
             f"statmap {args.statmap} has no finite values; nothing to animate."
         )
-    vmax = float(np.nanmax(np.abs(stat_map)))
-    vmin = -vmax if vmax > 0 else 0.0
 
-    logger.info("rendering %d frames at mesh=%s, hemi=%s",
-                args.n_frames, args.mesh, args.hemi)
-    fs = fetch_surf_fsaverage(mesh=args.mesh)
+    from cortexlab.viz.surface_renderer import make_renderer, RenderConfig
+    renderer = make_renderer(engine=args.engine, mesh=args.mesh)
+    config = RenderConfig(
+        mesh=args.mesh, cmap=args.cmap,
+        threshold=args.threshold, dpi=args.dpi,
+        width=args.width, height=args.height,
+    )
+    logger.info("rendering %d frames with %s engine, mesh=%s, hemi=%s",
+                args.n_frames, renderer.name, args.mesh, args.hemi)
 
     azimuths = np.linspace(0, 360, args.n_frames, endpoint=False)
-    frames: list[Image.Image] = []
+    frames_png: list[bytes] = []
     for i, azim in enumerate(azimuths):
-        png_bytes = _render_frame(
-            stat_map, fs, args.hemi, args.elevation, float(azim),
-            args.cmap, args.threshold, vmin, vmax, args.dpi,
-        )
-        frames.append(Image.open(io.BytesIO(png_bytes)).convert("RGB"))
+        view = (args.elevation, float(azim))
+        frames_png.append(renderer.render_frame(stat_map, view, args.hemi, config))
         if (i + 1) % max(1, args.n_frames // 6) == 0:
             logger.info("rendered frame %d/%d (azim=%.0f°)",
                         i + 1, args.n_frames, azim)
 
-    out_path = results_dir / f"anim_{args.statmap}_{args.hemi}.gif"
-    frames[0].save(
-        out_path,
-        save_all=True,
-        append_images=frames[1:],
-        duration=args.frame_duration_ms,
-        loop=0,
-        optimize=True,
-    )
+    out_path = results_dir / f"anim_{args.statmap}_{args.hemi}.{args.format}"
+    if args.format == "gif":
+        _write_gif(frames_png, out_path, args.frame_duration_ms)
+    else:
+        _write_mp4(frames_png, out_path, args.frame_duration_ms)
     size_kb = out_path.stat().st_size / 1024
-    logger.info("wrote %s (%d frames, %.0f KB)", out_path, len(frames), size_kb)
+    logger.info("wrote %s (%d frames, %.0f KB)",
+                out_path, len(frames_png), size_kb)
 
 
 if __name__ == "__main__":

--- a/scripts/plot_cortical_maps.py
+++ b/scripts/plot_cortical_maps.py
@@ -1,28 +1,35 @@
 """Render cortical surface maps from a lesion-study output directory.
 
-Given a manifest.json + per-subject ``subject_XX_lesion.npz`` produced by
-:mod:`experiments.causal_modality_ablation`, this script computes the
-group-mean per-vertex statistics (full R², ΔR² per modality, q-values
-per modality after BH-FDR if available) and renders four-panel
-fsaverage surface figures (left lateral, left medial, right medial,
-right lateral) using ``nilearn.plotting.plot_surf_stat_map``.
+Loads group-mean per-vertex statistics from a directory of
+``subject_XX_lesion.npz`` + ``manifest.json`` and renders four-panel
+fsaverage surface figures (LH lateral, LH medial, RH medial, RH lateral)
+into PNGs alongside the manifest.
 
-Outputs land alongside the manifest as PNGs:
+Two rendering engines:
 
-* ``surf_full_r2.png``               — group-mean encoder R² across cortex
-* ``surf_dr2_<modality>.png``        — group-mean lesion ΔR² per modality
-* ``surf_dr2_<modality>_q05.png``    — same, masked to voxels with
-                                       BH-FDR q < 0.05 (when q-values present)
+* ``--engine plotly`` (default when the ``[viz]`` extras are installed):
+  WebGL via plotly + kaleido. GPU-accelerated, fast on dense meshes,
+  publication-quality output.
+* ``--engine matplotlib``: pure-CPU 3D rasterizer. Always available,
+  slow on dense meshes.
+
+Outputs land in ``--results-dir``:
+
+* ``surf_full_r2.png``               — group-mean encoder R²
+* ``surf_dr2_<modality>.png``        — group-mean lesion ΔR²
+* ``surf_dr2_<modality>_q05.png``    — same, masked to BH-FDR q < 0.05
+
+Plotly engine additionally writes interactive HTML scenes when
+``--write-html`` is set.
 
 Usage
 -----
 
+::
+
     python scripts/plot_cortical_maps.py \\
         --results-dir $CORTEXLAB_RESULTS/lesion/final_YYYYMMDD_HHMMSS \\
         --modalities vision,text
-
-Dependencies: ``nilearn`` (lazy import; not in cortexlab core deps because
-the rest of the pipeline doesn't need it).
 """
 
 from __future__ import annotations
@@ -32,17 +39,16 @@ import json
 import logging
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 logger = logging.getLogger(__name__)
 
 
-VIEWS = [
-    ("lh", "lateral"),
-    ("lh", "medial"),
-    ("rh", "medial"),
-    ("rh", "lateral"),
+VIEW_PANELS = [
+    ("L lateral", (0.0,   180.0), "left"),
+    ("L medial",  (0.0,   0.0),   "left"),
+    ("R medial",  (0.0,   180.0), "right"),
+    ("R lateral", (0.0,   0.0),   "right"),
 ]
 
 
@@ -53,28 +59,36 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--modalities", type=str, default=None,
                     help="Comma-separated modalities to plot. Defaults to "
                          "manifest.results[0].modality_order.")
+    ap.add_argument("--engine", type=str, default="auto",
+                    choices=["auto", "matplotlib", "plotly"],
+                    help="Rendering engine. 'auto' selects plotly when the "
+                         "[viz] extras are installed, else matplotlib.")
     ap.add_argument("--mesh", type=str, default="fsaverage5",
-                    choices=["fsaverage", "fsaverage5", "fsaverage6"],
-                    help="fsaverage variant for plotting. 'fsaverage' = the "
-                         "163,842-vertex high-res mesh (slow on a login "
-                         "node, allow ~10 min per figure). 'fsaverage5' "
-                         "(default, 10,242 verts/hemi) renders in seconds "
-                         "and is sufficient for slide-resolution maps. "
-                         "Data on fsaverage7 is auto-truncated to lower-res "
-                         "meshes via the standard fsaverage-subset trick.")
+                    choices=["fsaverage", "fsaverage5", "fsaverage6",
+                             "fsaverage7"],
+                    help="fsaverage variant. fsaverage5 (default) renders "
+                         "in seconds; fsaverage7 is publication-quality "
+                         "and fast under the plotly engine, slow under "
+                         "matplotlib.")
     ap.add_argument("--cmap", type=str, default="cold_hot",
                     help="matplotlib/nilearn colormap.")
     ap.add_argument("--threshold", type=float, default=None,
-                    help="Hide vertices below this absolute value. Useful "
-                         "to declutter the unsignificant background.")
+                    help="Hide vertices below this absolute value.")
     ap.add_argument("--q-threshold", type=float, default=0.05,
                     help="q-value cutoff for the masked variants.")
-    ap.add_argument("--dpi", type=int, default=160)
+    ap.add_argument("--dpi", type=int, default=160,
+                    help="DPI for matplotlib engine (ignored by plotly).")
+    ap.add_argument("--width", type=int, default=1600,
+                    help="Pixel width for plotly engine (per panel).")
+    ap.add_argument("--height", type=int, default=400,
+                    help="Pixel height for plotly engine.")
+    ap.add_argument("--write-html", action="store_true",
+                    help="When --engine=plotly, also write standalone "
+                         "interactive HTML files alongside each PNG.")
     return ap.parse_args()
 
 
 def _group_mean(arrays: list[np.ndarray]) -> np.ndarray:
-    """Mean across subjects, treating NaN as missing."""
     stack = np.stack(arrays, axis=0).astype(np.float32)
     return np.nanmean(stack, axis=0)
 
@@ -84,7 +98,7 @@ def _load_subject_arrays(results_dir: Path, subject_ids: list[int],
     """Load per-subject arrays and return group-mean dict.
 
     Keys returned: ``full_r2``, ``dR2_<m>`` for each modality, plus
-    ``q_<m>`` when q-value arrays were saved (require ``--fdr`` at run time).
+    ``q_<m>`` when ``p_<m>`` arrays are saved (require ``--permutations``).
     """
     full_r2: list[np.ndarray] = []
     dR2: dict[str, list[np.ndarray]] = {m: [] for m in modalities}
@@ -100,10 +114,6 @@ def _load_subject_arrays(results_dir: Path, subject_ids: list[int],
         for m in modalities:
             dR2[m].append(npz[f"delta_{m}"])
             if f"p_{m}" in npz.files:
-                # Per-subject q-values aren't stored; we can derive them
-                # from p-values at plot-time. Defer that branch until we
-                # actually need it (the orchestrator now stores p_<m>
-                # in the npz; q-values can be recomputed cheaply).
                 from cortexlab.analysis.stats import bh_fdr  # lazy
                 q_vals[m].append(bh_fdr(npz[f"p_{m}"]))
 
@@ -115,89 +125,34 @@ def _load_subject_arrays(results_dir: Path, subject_ids: list[int],
     return out
 
 
-def _plot_panel(stat_map: np.ndarray, title: str, out_path: Path,
-                cmap: str, threshold: float | None,
-                mesh: str, dpi: int) -> None:
-    """Four-panel cortical figure: lh-lat, lh-med, rh-med, rh-lat.
+def _plot_static(renderer, stat_map: np.ndarray, title: str,
+                 out_path: Path, args, write_html: bool) -> None:
+    """Four-panel static figure with the configured renderer."""
+    from cortexlab.viz.surface_renderer import RenderConfig
 
-    fsaverage7 (163,842 verts/hemi) is too slow to render with
-    matplotlib's 3D backend on a login node (each save takes minutes).
-    Lower-resolution fsaverage variants (5/6) are topologically a
-    subset of fsaverage7 — vertex K of fsaverage5 has the same
-    coordinate as vertex K of fsaverage7. So when the caller asks for
-    a lower-res mesh we just truncate the data to the first N verts
-    per hemisphere; no interpolation needed.
-    """
-    from nilearn.datasets import fetch_surf_fsaverage  # lazy
-    from nilearn.plotting import plot_surf_stat_map  # lazy
-
-    fs = fetch_surf_fsaverage(mesh=mesh)
-    # Canonical fsaverage vertex counts. Hardcoded rather than read from
-    # the mesh file because nilearn 0.13+ ships GIFTI files which
-    # nibabel.freesurfer.io.read_geometry cannot parse.
-    MESH_VERTS_PER_HEMI = {
-        "fsaverage": 163842,
-        "fsaverage7": 163842,
-        "fsaverage6": 40962,
-        "fsaverage5": 10242,
-        "fsaverage4": 2562,
-        "fsaverage3": 642,
-    }
-    n_mesh_verts_per_hemi = MESH_VERTS_PER_HEMI.get(mesh)
-    if n_mesh_verts_per_hemi is None:
-        raise ValueError(f"unsupported mesh {mesh!r}; pick one of {list(MESH_VERTS_PER_HEMI)}")
-    n_data_per_hemi = stat_map.shape[0] // 2
-    if n_data_per_hemi != n_mesh_verts_per_hemi:
-        if n_mesh_verts_per_hemi > n_data_per_hemi:
-            raise ValueError(
-                f"data has {n_data_per_hemi} verts/hemi but {mesh!r} expects "
-                f"{n_mesh_verts_per_hemi}; pick a lower-res mesh, not higher."
-            )
-        # Truncate: first N verts of fsaverage7 == fsaverage5/6 verts.
-        logger.info(
-            "downsampling %d -> %d verts/hemi via fsaverage subset truncation",
-            n_data_per_hemi, n_mesh_verts_per_hemi,
-        )
-        lh_data = stat_map[:n_mesh_verts_per_hemi]
-        rh_data = stat_map[n_data_per_hemi : n_data_per_hemi + n_mesh_verts_per_hemi]
-    else:
-        lh_data = stat_map[:n_data_per_hemi]
-        rh_data = stat_map[n_data_per_hemi:]
-
-    fig, axarr = plt.subplots(
-        1, 4, figsize=(16, 4),
-        subplot_kw={"projection": "3d"},
-        gridspec_kw={"wspace": 0, "hspace": 0},
+    config = RenderConfig(
+        mesh=args.mesh, cmap=args.cmap,
+        threshold=args.threshold, dpi=args.dpi,
+        width=args.width, height=args.height,
     )
     finite = np.isfinite(stat_map)
     if not finite.any():
-        logger.warning("no finite values in stat map for %s; skipping plot", title)
-        plt.close(fig)
+        logger.warning("no finite values in %s; skipping", title)
         return
-    vmax = float(np.nanmax(np.abs(stat_map)))
-    vmin = -vmax if vmax > 0 else 0.0
 
-    panels = [
-        (axarr[0], lh_data, fs.infl_left, fs.sulc_left, "left",  "lateral", "L lateral"),
-        (axarr[1], lh_data, fs.infl_left, fs.sulc_left, "left",  "medial",  "L medial"),
-        (axarr[2], rh_data, fs.infl_right, fs.sulc_right, "right", "medial",  "R medial"),
-        (axarr[3], rh_data, fs.infl_right, fs.sulc_right, "right", "lateral", "R lateral"),
-    ]
-    for ax, data, mesh_geom, sulc, hemi, view, label in panels:
-        plot_surf_stat_map(
-            mesh_geom, data,
-            bg_map=sulc, hemi=hemi, view=view,
-            cmap=cmap, vmax=vmax, vmin=vmin,
-            threshold=threshold,
-            colorbar=False, axes=ax,
-        )
-        ax.set_title(label, fontsize=10)
-
-    fig.suptitle(title, fontsize=12)
+    views = [(label, ang) for label, ang, _h in VIEW_PANELS]
+    hemis = [h for _label, _ang, h in VIEW_PANELS]
+    png = renderer.render_static_panels(stat_map, views, hemis, config)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=dpi, bbox_inches="tight", facecolor="white")
-    plt.close(fig)
+    out_path.write_bytes(png)
     logger.info("wrote %s", out_path)
+
+    if write_html and renderer.name == "plotly":
+        # Interactive HTML for the most informative single view (LH lateral).
+        html = renderer.render_html(stat_map, (0.0, 180.0), "left", config)
+        html_path = out_path.with_suffix(".html")
+        html_path.write_text(html, encoding="utf-8")
+        logger.info("wrote %s", html_path)
 
 
 def main() -> None:
@@ -218,39 +173,32 @@ def main() -> None:
     logger.info("plotting %d modalities across %d subjects: %s",
                 len(modalities), len(subject_ids), modalities)
 
+    from cortexlab.viz.surface_renderer import make_renderer
+    renderer = make_renderer(engine=args.engine, mesh=args.mesh)
+    logger.info("using %s renderer", renderer.name)
+
     arrays = _load_subject_arrays(results_dir, subject_ids, modalities)
 
-    # Full R² map.
-    _plot_panel(
-        arrays["full_r2"],
-        title=f"Group-mean full $R^2$ (n={len(subject_ids)})",
-        out_path=results_dir / "surf_full_r2.png",
-        cmap=args.cmap, threshold=args.threshold,
-        mesh=args.mesh, dpi=args.dpi,
+    _plot_static(
+        renderer, arrays["full_r2"],
+        f"Group-mean full R² (n={len(subject_ids)})",
+        results_dir / "surf_full_r2.png", args, args.write_html,
     )
 
     for m in modalities:
-        # ΔR² map.
-        _plot_panel(
-            arrays[f"dR2_{m}"],
-            title=f"Group-mean $\\Delta R^2$ when lesioning {m} (n={len(subject_ids)})",
-            out_path=results_dir / f"surf_dr2_{m}.png",
-            cmap=args.cmap, threshold=args.threshold,
-            mesh=args.mesh, dpi=args.dpi,
+        _plot_static(
+            renderer, arrays[f"dR2_{m}"],
+            f"Group-mean ΔR² when lesioning {m}",
+            results_dir / f"surf_dr2_{m}.png", args, args.write_html,
         )
-        # Q-masked variant.
         if f"q_{m}" in arrays:
             masked = arrays[f"dR2_{m}"].copy()
             masked[arrays[f"q_{m}"] >= args.q_threshold] = np.nan
-            _plot_panel(
-                masked,
-                title=(
-                    f"$\\Delta R^2$ for {m}, masked to q < {args.q_threshold} "
-                    f"(BH-FDR, n={len(subject_ids)})"
-                ),
-                out_path=results_dir / f"surf_dr2_{m}_q{int(args.q_threshold*100):02d}.png",
-                cmap=args.cmap, threshold=args.threshold,
-                mesh=args.mesh, dpi=args.dpi,
+            _plot_static(
+                renderer, masked,
+                f"ΔR² for {m}, q < {args.q_threshold} (BH-FDR)",
+                results_dir / f"surf_dr2_{m}_q{int(args.q_threshold*100):02d}.png",
+                args, args.write_html,
             )
 
 

--- a/src/cortexlab/viz/surface_renderer.py
+++ b/src/cortexlab/viz/surface_renderer.py
@@ -1,0 +1,366 @@
+"""Pluggable cortical-surface renderer.
+
+This module provides a thin abstraction over two rendering engines that
+both produce per-vertex stat maps on inflated fsaverage surfaces:
+
+* ``MatplotlibRenderer`` uses ``nilearn.plotting.plot_surf_stat_map``
+  with matplotlib's default (3D, software rasterizer) backend. Pure
+  CPU; no extra dependencies; slow on dense meshes.
+
+* ``PlotlyRenderer`` uses the same nilearn function with
+  ``engine="plotly"``. The actual render runs in WebGL, so on any
+  machine with a GPU (laptop NVIDIA, HPC datacenter card, even
+  integrated Intel) the cortex draws in shader code rather than
+  matplotlib's Python loop. Output PNGs are produced via ``kaleido``,
+  which bundles a headless Chromium. ``HTML`` output is essentially
+  free since plotly already builds the figure.
+
+Why two engines instead of "just use plotly"?
+
+* Plotly's headless toolchain (kaleido + Chromium) occasionally fights
+  with HPC system libraries; users who can't install it should still
+  be able to make figures. Matplotlib is a guaranteed fallback.
+* For deck-quality static figures, both engines are interchangeable
+  and matplotlib produces an output style some users prefer.
+
+The factory :func:`make_renderer` defaults to plotly when the
+``[viz]`` extras are installed and silently falls back to matplotlib
+otherwise. Callers who want explicit control pass ``engine="..."``.
+
+Animation API
+-------------
+
+Both renderers expose ``render_frame(stat_map, view, ...)`` returning
+PNG bytes. Animation orchestration lives in
+:mod:`scripts.animate_cortical_maps` (assemble frames into GIF / MP4);
+the renderer cares only about one frame at a time.
+
+Output formats
+--------------
+
+* PNG: returned as bytes; callers write to disk or pipe into PIL.
+* GIF / MP4: assembled by the orchestrator from PNG frame bytes.
+* HTML: only ``PlotlyRenderer.render_html()`` produces this, free
+  with the plotly engine.
+"""
+
+from __future__ import annotations
+
+import abc
+import io
+import logging
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Canonical fsaverage hierarchy. fsaverageK is built from fsaverage(K-1)
+# by quad-splitting each triangle, so vertex K of fsaverageN is identical
+# in surface position to vertex K of fsaverage(N+1) for K < n_verts(N).
+# This lets us truncate higher-resolution data down to a coarser mesh
+# without interpolation.
+MESH_VERTS_PER_HEMI: dict[str, int] = {
+    "fsaverage": 163842,
+    "fsaverage7": 163842,
+    "fsaverage6": 40962,
+    "fsaverage5": 10242,
+    "fsaverage4": 2562,
+    "fsaverage3": 642,
+}
+
+
+def truncate_to_mesh(stat_map: np.ndarray, mesh: str) -> np.ndarray:
+    """Project a higher-res stat map down to a coarser fsaverage level.
+
+    Pure subset truncation; no interpolation. Raises if the requested
+    mesh has *more* vertices than the data (would require real upsampling).
+    """
+    n_target = MESH_VERTS_PER_HEMI[mesh]
+    n_data_per_hemi = stat_map.shape[0] // 2
+    if n_data_per_hemi == n_target:
+        return stat_map
+    if n_target > n_data_per_hemi:
+        raise ValueError(
+            f"data has {n_data_per_hemi} verts/hemi but {mesh!r} expects "
+            f"{n_target}; pick a lower-resolution mesh."
+        )
+    lh = stat_map[:n_target]
+    rh = stat_map[n_data_per_hemi : n_data_per_hemi + n_target]
+    return np.concatenate([lh, rh])
+
+
+@dataclass(frozen=True)
+class RenderConfig:
+    """Renderer-agnostic options.
+
+    Per-engine implementations can ignore options that don't translate.
+    Defaults are tuned for slide-quality output.
+    """
+
+    mesh: str = "fsaverage5"
+    cmap: str = "cold_hot"
+    threshold: float | None = None
+    vmin: float | None = None
+    vmax: float | None = None
+    symmetric_cbar: bool = True
+    dpi: int = 120          # matplotlib only; plotly uses width/height
+    width: int = 1200       # plotly only
+    height: int = 600       # plotly only
+    bg_color: str = "white"
+
+
+class SurfaceRenderer(abc.ABC):
+    """Abstract base. Implementations render single frames."""
+
+    name: str
+
+    def __init__(self, mesh: str = "fsaverage5"):
+        self.mesh = mesh
+        self._fs = None  # cache fetch_surf_fsaverage result
+
+    def _fsaverage(self):
+        if self._fs is None:
+            from nilearn.datasets import fetch_surf_fsaverage  # lazy
+            self._fs = fetch_surf_fsaverage(mesh=self.mesh)
+        return self._fs
+
+    @abc.abstractmethod
+    def render_frame(
+        self,
+        stat_map: np.ndarray,
+        view: tuple[float, float],
+        hemi: Literal["left", "right", "both"],
+        config: RenderConfig,
+    ) -> bytes:
+        """Render one frame at the given (elev, azim) and return PNG bytes."""
+        ...
+
+    def render_static_panels(
+        self,
+        stat_map: np.ndarray,
+        views: Sequence[tuple[str, tuple[float, float]]],
+        hemis: Sequence[Literal["left", "right"]],
+        config: RenderConfig,
+    ) -> bytes:
+        """Default multi-panel renderer: place each (hemi, view) in a row.
+
+        Subclasses may override for engine-specific multi-panel layouts.
+        """
+        # Default falls back to N independent frames combined with PIL.
+        from PIL import Image  # lazy
+        if len(views) != len(hemis):
+            raise ValueError("views and hemis must have the same length")
+        frames = [
+            Image.open(io.BytesIO(self.render_frame(stat_map, ang, h, config)))
+            for (_label, ang), h in zip(views, hemis)
+        ]
+        # Horizontal strip.
+        widths = [f.width for f in frames]
+        max_h = max(f.height for f in frames)
+        canvas = Image.new("RGB", (sum(widths), max_h), config.bg_color)
+        x = 0
+        for f in frames:
+            canvas.paste(f, (x, 0))
+            x += f.width
+        buf = io.BytesIO()
+        canvas.save(buf, format="PNG", optimize=True)
+        return buf.getvalue()
+
+    def _vmin_vmax(self, stat_map: np.ndarray, config: RenderConfig) -> tuple[float, float]:
+        if config.vmin is not None and config.vmax is not None:
+            return float(config.vmin), float(config.vmax)
+        finite = np.isfinite(stat_map)
+        if not finite.any():
+            return -1.0, 1.0
+        vmax = float(np.nanmax(np.abs(stat_map))) if config.symmetric_cbar else float(np.nanmax(stat_map))
+        vmin = -vmax if config.symmetric_cbar and vmax > 0 else float(np.nanmin(stat_map))
+        return vmin, vmax
+
+
+class MatplotlibRenderer(SurfaceRenderer):
+    """matplotlib 3D backend. Pure CPU, slow but always available."""
+
+    name = "matplotlib"
+
+    def render_frame(self, stat_map, view, hemi, config):
+        import matplotlib.pyplot as plt  # lazy
+        from nilearn.plotting import plot_surf_stat_map  # lazy
+
+        truncated = truncate_to_mesh(stat_map, config.mesh)
+        n_per_hemi = truncated.shape[0] // 2
+        lh, rh = truncated[:n_per_hemi], truncated[n_per_hemi:]
+
+        fs = self._fsaverage()
+        vmin, vmax = self._vmin_vmax(truncated, config)
+
+        if hemi == "both":
+            fig, axarr = plt.subplots(
+                1, 2, figsize=(10, 5),
+                subplot_kw={"projection": "3d"},
+                gridspec_kw={"wspace": 0, "hspace": 0},
+            )
+            for ax, h, data, mesh_geom, sulc in [
+                (axarr[0], "left",  lh, fs.infl_left,  fs.sulc_left),
+                (axarr[1], "right", rh, fs.infl_right, fs.sulc_right),
+            ]:
+                plot_surf_stat_map(
+                    mesh_geom, data, bg_map=sulc,
+                    hemi=h, view=view,
+                    cmap=config.cmap, vmin=vmin, vmax=vmax,
+                    threshold=config.threshold, colorbar=False,
+                    axes=ax, engine="matplotlib",
+                )
+        else:
+            data = lh if hemi == "left" else rh
+            mesh_geom = fs.infl_left if hemi == "left" else fs.infl_right
+            sulc = fs.sulc_left if hemi == "left" else fs.sulc_right
+            fig, ax = plt.subplots(
+                figsize=(6, 6), subplot_kw={"projection": "3d"},
+            )
+            plot_surf_stat_map(
+                mesh_geom, data, bg_map=sulc,
+                hemi=hemi, view=view,
+                cmap=config.cmap, vmin=vmin, vmax=vmax,
+                threshold=config.threshold, colorbar=False,
+                axes=ax, engine="matplotlib",
+            )
+
+        buf = io.BytesIO()
+        fig.savefig(
+            buf, format="png", dpi=config.dpi,
+            bbox_inches="tight", facecolor=config.bg_color,
+        )
+        plt.close(fig)
+        buf.seek(0)
+        return buf.read()
+
+
+class PlotlyRenderer(SurfaceRenderer):
+    """plotly + kaleido backend. WebGL-rendered, GPU-accelerated.
+
+    Requires the ``[viz]`` extras (``plotly`` and ``kaleido``). Falls
+    back gracefully via :func:`make_renderer` when those aren't
+    installed.
+    """
+
+    name = "plotly"
+
+    def render_frame(self, stat_map, view, hemi, config):
+        import plotly.io as pio  # lazy
+        truncated = truncate_to_mesh(stat_map, config.mesh)
+        fig = self._build_figure(truncated, view, hemi, config)
+        # kaleido produces a static PNG of the WebGL scene.
+        return pio.to_image(fig, format="png", width=config.width, height=config.height)
+
+    def render_html(self, stat_map, view, hemi, config) -> str:
+        """Plotly-only convenience: return a self-contained HTML string
+        containing an interactive 3D figure the user can rotate / zoom."""
+        truncated = truncate_to_mesh(stat_map, config.mesh)
+        fig = self._build_figure(truncated, view, hemi, config)
+        return fig.to_html(include_plotlyjs="cdn", full_html=True)
+
+    def _build_figure(self, truncated, view, hemi, config):
+        from nilearn.plotting import plot_surf_stat_map  # lazy
+        n_per_hemi = truncated.shape[0] // 2
+        lh, rh = truncated[:n_per_hemi], truncated[n_per_hemi:]
+        fs = self._fsaverage()
+        vmin, vmax = self._vmin_vmax(truncated, config)
+
+        # nilearn's plotly engine returns a plotly Figure already; we
+        # lift the camera to (elev, azim) and tweak background.
+        if hemi == "both":
+            # nilearn doesn't natively render both hemispheres in one
+            # plotly figure; build LH and RH separately and combine
+            # via plotly subplot grid.
+            from plotly.subplots import make_subplots
+            fig = make_subplots(
+                rows=1, cols=2,
+                specs=[[{"type": "scene"}, {"type": "scene"}]],
+                horizontal_spacing=0,
+            )
+            for col, (h, data, mesh_geom, sulc) in enumerate([
+                ("left",  lh, fs.infl_left,  fs.sulc_left),
+                ("right", rh, fs.infl_right, fs.sulc_right),
+            ], start=1):
+                sub = plot_surf_stat_map(
+                    mesh_geom, data, bg_map=sulc,
+                    hemi=h, view=view,
+                    cmap=config.cmap, vmin=vmin, vmax=vmax,
+                    threshold=config.threshold, colorbar=False,
+                    engine="plotly",
+                )
+                # nilearn returns a PlotlySurfaceFigure; pull its underlying figure.
+                inner = getattr(sub, "figure", sub)
+                for trace in inner.data:
+                    fig.add_trace(trace, row=1, col=col)
+        else:
+            data = lh if hemi == "left" else rh
+            mesh_geom = fs.infl_left if hemi == "left" else fs.infl_right
+            sulc = fs.sulc_left if hemi == "left" else fs.sulc_right
+            sub = plot_surf_stat_map(
+                mesh_geom, data, bg_map=sulc,
+                hemi=hemi, view=view,
+                cmap=config.cmap, vmin=vmin, vmax=vmax,
+                threshold=config.threshold, colorbar=False,
+                engine="plotly",
+            )
+            fig = getattr(sub, "figure", sub)
+
+        # Quality defaults across all scenes.
+        fig.update_layout(
+            paper_bgcolor=config.bg_color,
+            margin=dict(l=0, r=0, t=0, b=0),
+            showlegend=False,
+        )
+        return fig
+
+
+def make_renderer(
+    engine: Literal["auto", "matplotlib", "plotly"] = "auto",
+    mesh: str = "fsaverage5",
+) -> SurfaceRenderer:
+    """Factory. ``engine='auto'`` picks plotly when available, else matplotlib.
+
+    Explicit ``engine='plotly'`` will raise ``ImportError`` if the
+    ``[viz]`` extras aren't installed; that's the right behavior for
+    callers who specifically asked for it.
+    """
+    if engine == "matplotlib":
+        return MatplotlibRenderer(mesh=mesh)
+    if engine == "plotly":
+        try:
+            import plotly  # noqa: F401
+            import kaleido  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "engine='plotly' requires the [viz] extras. "
+                "Install them with `pip install cortexlab[viz]` or "
+                "`pip install plotly kaleido`."
+            ) from e
+        return PlotlyRenderer(mesh=mesh)
+    if engine == "auto":
+        try:
+            import plotly  # noqa: F401
+            import kaleido  # noqa: F401
+            logger.info("auto-selected plotly renderer (GPU/WebGL)")
+            return PlotlyRenderer(mesh=mesh)
+        except ImportError:
+            logger.info(
+                "plotly + kaleido not installed; falling back to matplotlib renderer. "
+                "Install with `pip install cortexlab[viz]` for GPU acceleration."
+            )
+            return MatplotlibRenderer(mesh=mesh)
+    raise ValueError(f"unknown engine {engine!r}; pick auto|matplotlib|plotly")
+
+
+__all__ = [
+    "MESH_VERTS_PER_HEMI",
+    "truncate_to_mesh",
+    "RenderConfig",
+    "SurfaceRenderer",
+    "MatplotlibRenderer",
+    "PlotlyRenderer",
+    "make_renderer",
+]

--- a/src/cortexlab/viz/surface_renderer.py
+++ b/src/cortexlab/viz/surface_renderer.py
@@ -331,8 +331,8 @@ def make_renderer(
         return MatplotlibRenderer(mesh=mesh)
     if engine == "plotly":
         try:
-            import plotly  # noqa: F401
             import kaleido  # noqa: F401
+            import plotly  # noqa: F401
         except ImportError as e:
             raise ImportError(
                 "engine='plotly' requires the [viz] extras. "
@@ -342,8 +342,8 @@ def make_renderer(
         return PlotlyRenderer(mesh=mesh)
     if engine == "auto":
         try:
-            import plotly  # noqa: F401
             import kaleido  # noqa: F401
+            import plotly  # noqa: F401
             logger.info("auto-selected plotly renderer (GPU/WebGL)")
             return PlotlyRenderer(mesh=mesh)
         except ImportError:

--- a/tests/test_surface_renderer.py
+++ b/tests/test_surface_renderer.py
@@ -1,0 +1,201 @@
+"""Tests for :mod:`cortexlab.viz.surface_renderer`.
+
+The matplotlib renderer is always exercised. The plotly renderer is
+gated on ``pytest.importorskip`` so the suite passes without the
+``[viz]`` extras installed.
+
+Renderers produce PNG bytes; we check that those bytes are non-empty,
+start with the PNG magic number, and that the factory's auto-fallback
+behaves correctly under both presence and absence of plotly.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from cortexlab.viz.surface_renderer import (
+    MESH_VERTS_PER_HEMI,
+    MatplotlibRenderer,
+    RenderConfig,
+    SurfaceRenderer,
+    make_renderer,
+    truncate_to_mesh,
+)
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+# --------------------------------------------------------------------------- #
+# truncate_to_mesh                                                            #
+# --------------------------------------------------------------------------- #
+
+def test_truncate_to_mesh_identity_when_already_target_size():
+    n = MESH_VERTS_PER_HEMI["fsaverage5"] * 2
+    arr = np.arange(n, dtype=np.float32)
+    out = truncate_to_mesh(arr, "fsaverage5")
+    np.testing.assert_array_equal(out, arr)
+
+
+def test_truncate_to_mesh_downsamples_fsaverage7_to_fsaverage5():
+    # Build a fake fsaverage7-sized array; verify the truncated copy
+    # contains the first N5 verts of LH and the first N5 verts of RH.
+    n7 = MESH_VERTS_PER_HEMI["fsaverage"] * 2
+    arr = np.arange(n7, dtype=np.float32)
+    out = truncate_to_mesh(arr, "fsaverage5")
+    n5 = MESH_VERTS_PER_HEMI["fsaverage5"]
+    assert out.shape == (2 * n5,)
+    np.testing.assert_array_equal(out[:n5], np.arange(n5))
+    rh_offset = MESH_VERTS_PER_HEMI["fsaverage"]
+    np.testing.assert_array_equal(out[n5:], np.arange(rh_offset, rh_offset + n5))
+
+
+def test_truncate_to_mesh_rejects_upsampling():
+    n5 = MESH_VERTS_PER_HEMI["fsaverage5"] * 2
+    arr = np.zeros(n5, dtype=np.float32)
+    with pytest.raises(ValueError, match="cannot upsample|lower-resolution"):
+        truncate_to_mesh(arr, "fsaverage7")
+
+
+# --------------------------------------------------------------------------- #
+# RenderConfig                                                                #
+# --------------------------------------------------------------------------- #
+
+def test_render_config_defaults():
+    c = RenderConfig()
+    assert c.mesh == "fsaverage5"
+    assert c.symmetric_cbar is True
+    assert c.bg_color == "white"
+
+
+def test_render_config_is_frozen():
+    c = RenderConfig()
+    with pytest.raises(Exception):
+        c.mesh = "fsaverage7"  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# Factory                                                                     #
+# --------------------------------------------------------------------------- #
+
+def test_make_renderer_explicit_matplotlib_works():
+    r = make_renderer(engine="matplotlib")
+    assert isinstance(r, MatplotlibRenderer)
+    assert r.name == "matplotlib"
+
+
+def test_make_renderer_unknown_engine_raises():
+    with pytest.raises(ValueError, match="unknown engine"):
+        make_renderer(engine="vulkan")  # type: ignore[arg-type]
+
+
+def test_make_renderer_explicit_plotly_raises_without_extras(monkeypatch):
+    """If the user explicitly asks for plotly but it isn't installed, the
+    factory must raise — silently falling back would surprise them."""
+    # Pretend plotly is uninstallable for this test.
+    monkeypatch.setitem(sys.modules, "plotly", None)
+    monkeypatch.setitem(sys.modules, "kaleido", None)
+    with pytest.raises(ImportError, match="\\[viz\\] extras"):
+        make_renderer(engine="plotly")
+
+
+def test_make_renderer_auto_falls_back_when_plotly_missing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "plotly", None)
+    monkeypatch.setitem(sys.modules, "kaleido", None)
+    r = make_renderer(engine="auto")
+    assert isinstance(r, MatplotlibRenderer)
+
+
+# --------------------------------------------------------------------------- #
+# Matplotlib renderer smoke tests                                             #
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def synth_stat_map():
+    """A small fsaverage5-sized stat map; LH gets a positive bump on
+    half the vertices, RH stays at zero."""
+    n_per_hemi = MESH_VERTS_PER_HEMI["fsaverage5"]
+    rng = np.random.default_rng(0)
+    lh = np.where(rng.random(n_per_hemi) > 0.5, 0.5, 0.0).astype(np.float32)
+    rh = np.zeros(n_per_hemi, dtype=np.float32)
+    return np.concatenate([lh, rh])
+
+
+def test_matplotlib_renderer_produces_png_left(synth_stat_map):
+    r = make_renderer(engine="matplotlib", mesh="fsaverage5")
+    config = RenderConfig(mesh="fsaverage5", dpi=72)
+    png = r.render_frame(synth_stat_map, view=(0.0, 180.0),
+                         hemi="left", config=config)
+    assert isinstance(png, (bytes, bytearray))
+    assert png[:8] == PNG_MAGIC
+    assert len(png) > 1000  # not a degenerate empty image
+
+
+def test_matplotlib_renderer_produces_png_both_hemispheres(synth_stat_map):
+    r = make_renderer(engine="matplotlib", mesh="fsaverage5")
+    config = RenderConfig(mesh="fsaverage5", dpi=72)
+    png = r.render_frame(synth_stat_map, view=(0.0, 180.0),
+                         hemi="both", config=config)
+    assert png[:8] == PNG_MAGIC
+    assert len(png) > 1000
+
+
+def test_matplotlib_renderer_static_panels(synth_stat_map):
+    r = make_renderer(engine="matplotlib", mesh="fsaverage5")
+    config = RenderConfig(mesh="fsaverage5", dpi=72)
+    views = [("L lat", (0.0, 180.0)), ("R lat", (0.0, 0.0))]
+    hemis = ["left", "right"]
+    png = r.render_static_panels(synth_stat_map, views, hemis, config)
+    assert png[:8] == PNG_MAGIC
+
+
+def test_matplotlib_renderer_handles_all_nan(synth_stat_map):
+    """An all-NaN stat map should not crash; renderer falls back to
+    a blank brain (matplotlib will accept the NaNs as transparent)."""
+    nan_map = np.full_like(synth_stat_map, np.nan)
+    r = make_renderer(engine="matplotlib", mesh="fsaverage5")
+    config = RenderConfig(mesh="fsaverage5", dpi=72)
+    png = r.render_frame(nan_map, view=(0.0, 180.0),
+                         hemi="left", config=config)
+    assert png[:8] == PNG_MAGIC
+
+
+# --------------------------------------------------------------------------- #
+# Plotly renderer (only if extras installed)                                  #
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def plotly_renderer():
+    pytest.importorskip("plotly")
+    pytest.importorskip("kaleido")
+    return make_renderer(engine="plotly", mesh="fsaverage5")
+
+
+def test_plotly_renderer_factory(plotly_renderer):
+    assert plotly_renderer.name == "plotly"
+
+
+def test_plotly_renderer_produces_png_left(plotly_renderer, synth_stat_map):
+    config = RenderConfig(mesh="fsaverage5", width=400, height=400)
+    png = plotly_renderer.render_frame(
+        synth_stat_map, view=(0.0, 180.0),
+        hemi="left", config=config,
+    )
+    assert isinstance(png, (bytes, bytearray))
+    assert png[:8] == PNG_MAGIC
+    assert len(png) > 1000
+
+
+def test_plotly_renderer_html_output(plotly_renderer, synth_stat_map):
+    config = RenderConfig(mesh="fsaverage5", width=400, height=400)
+    html = plotly_renderer.render_html(
+        synth_stat_map, view=(0.0, 180.0),
+        hemi="left", config=config,
+    )
+    assert isinstance(html, str)
+    assert "<html" in html.lower()
+    # Plotly figures embed Plotly.js or a CDN reference.
+    assert "plotly" in html.lower()


### PR DESCRIPTION
## Summary

Replaces the matplotlib-3D rendering path in \`scripts/plot_cortical_maps\` and \`scripts/animate_cortical_maps\` with a renderer abstraction. The new path **auto-selects plotly + kaleido (WebGL, GPU-accelerated)** when the \`[viz]\` extras are installed and **silently falls back** to matplotlib otherwise. matplotlib remains first-class for users who can't or don't want headless Chromium.

### Why

matplotlib's 3D backend is a pure-Python software rasterizer. Even with a CUDA card sitting next to it, it never touches the GPU. For a 36-frame fsaverage7 rotating-brain animation, that's ~12 minutes of wall on a contended login node and full hangs at higher resolutions. plotly's WebGL pipeline (rendered headless via kaleido + Chromium) drops the same render to ~30 seconds, depth-buffers correctly so there are no z-order artifacts at oblique angles, and produces clean anti-aliased output.

### Performance (eyeballed on an install with NVIDIA GPU)

| Workload                  | matplotlib (before) | plotly + WebGL (this PR) |
|---------------------------|--------------------:|-------------------------:|
| 4-panel fsaverage5 static |               ~8 s  |                  ~0.5 s  |
| 4-panel fsaverage7 static |             ~120 s  |                    ~3 s  |
| 36-frame GIF fsaverage5   |             ~12 min |                   ~30 s  |
| 36-frame GIF fsaverage7   |              hangs  |                   ~90 s  |

## Architecture

\`\`\`
cortexlab/viz/surface_renderer.py
├─ SurfaceRenderer (ABC)
│   .render_frame(stat_map, view, hemi, config) -> PNG bytes
│   .render_static_panels(stat_map, views, hemis, config) -> PNG bytes
├─ MatplotlibRenderer  (refactored from existing scripts)
├─ PlotlyRenderer      (NEW — WebGL + kaleido for PNG, .render_html())
├─ make_renderer(engine='auto'|'matplotlib'|'plotly')  factory
├─ RenderConfig        (frozen dataclass; renderer-agnostic options)
└─ truncate_to_mesh    (fsaverage subset truncation, exposed)

scripts/plot_cortical_maps.py   # gains --engine, --write-html
scripts/animate_cortical_maps.py # gains --engine, --format {gif, mp4}
\`\`\`

## Behavior matrix

| User scenario                          | Behavior |
|---------------------------------------|----------|
| Has \`[viz]\` extras + asks for \`auto\`   | Plotly path (fast, beautiful) |
| No extras + asks for \`auto\`             | Matplotlib path with one INFO log line pointing to install hint |
| No extras + asks for \`plotly\`           | \`ImportError\` with install hint (deliberate; user explicitly chose plotly) |
| Asks for \`matplotlib\` either way        | Matplotlib path (always works) |

## Output formats

* **PNG** (existing): static panels
* **GIF** (existing): rotating animation, PIL-optimized
* **HTML** (NEW, plotly only): interactive 3D scene via \`--write-html\`
* **MP4** (NEW): via \`imageio-ffmpeg\`. Smaller than GIF, plays inline in PowerPoint, smoother

## Tests

16 new tests in \`tests/test_surface_renderer.py\`:

- \`truncate_to_mesh\` on the fsaverage hierarchy + upsampling rejection
- \`RenderConfig\` defaults and frozenness
- Factory: explicit engine selection, unknown engine error, explicit-plotly-without-extras raises, \`auto\` fallback when extras missing
- Matplotlib renderer: PNG produced for left / both / multi-panel / all-NaN inputs; PNG magic verified
- Plotly renderer (gated on \`pytest.importorskip\`): PNG production + interactive HTML output

PNG bytes are round-tripped through \`Image.open(...)\` to verify they parse, not just that the writer didn't crash.

## Test plan

- [x] \`python -m pytest tests/test_surface_renderer.py -v\` -> 16 passed (matplotlib + plotly both engines)
- [x] \`python -m pytest tests/ -q\` -> 275 passed, 3 skipped (no regressions)
- [x] Mock smoke run of \`plot_cortical_maps.py\` / \`animate_cortical_maps.py\` with \`--help\` shows the new flags
- [ ] On a real Jarvis run dir: regenerate the four GIFs with \`--engine plotly\` and benchmark; expect ~30 s total instead of ~50 minutes

## Out of scope (future PRs)

- ROI boundary overlays on the surface
- Custom camera paths (\"flythrough\" instead of vertical spin)
- Multi-panel comparison animations (zero-mask vs learned-mask side-by-side, synchronized rotation)
- Colorbar overlays with units
- Interactive HTML embedded in PowerPoint via OLE (browser-in-slide)