### PR TITLE
fix: rename ambiguous `l` loop variable in loader.py to silence E741

### DIFF
--- a/src/cortexlab/data/loader.py
+++ b/src/cortexlab/data/loader.py
@@ -433,7 +433,7 @@ def get_topk_rois(data: np.ndarray, hemi="both", mesh="fsaverage5", k=10) -> np.
     if hemi == "both_separate":
         left_labels = get_hcp_labels(mesh=mesh, combine=False, hemi="left").keys()
         right_labels = get_hcp_labels(mesh=mesh, combine=False, hemi="right").keys()
-        labels = [f"{l}-lh" for l in left_labels] + [f"{l}-rh" for l in right_labels]
+        labels = [f"{label}-lh" for label in left_labels] + [f"{label}-rh" for label in right_labels]
     else:
         labels = get_hcp_labels(mesh=mesh, combine=False, hemi=hemi).keys()
     top_k = np.argsort(values)[::-1][:k]


### PR DESCRIPTION
## Summary

Closes #23.

Two \`E741\` ruff lint errors on
\`src/cortexlab/data/loader.py:436\`:

\`\`\`python
labels = [f\"{l}-lh\" for l in left_labels] + [f\"{l}-rh\" for l in right_labels]
\`\`\`

The variable name \`l\` is ambiguous (looks like a \`1\`) and is
rejected by ruff's E741. Renamed both occurrences to \`label\` per
the issue's suggestion. Same iteration, same output, clearer
reading.

## Test plan

- [x] \`ruff check src/cortexlab/data/loader.py\` — \`All checks
      passed!\` after the change.
- [x] \`python3 -c \"import ast; ast.parse(...)\"\` — file still
      parses cleanly.
- [x] No production logic touched; the rename is a pure-naming
      change inside two list comprehensions.

The other ruff findings under \`src/\` are in unrelated files and
predate this change.