### PR TITLE
chore: ruff sweep across src/ — auto-fixable + dead code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ wandb/
 .env
 experiments/results/*.json
 *.onnx
+
+# Local session/working files (never committed)
+SESSION_STATE.md

--- a/src/cortexlab/__init__.py
+++ b/src/cortexlab/__init__.py
@@ -7,8 +7,8 @@ brain-alignment benchmarking, and cognitive load scoring.
 
 __version__ = "0.1.0"
 
-from cortexlab.core.model import FmriEncoder, FmriEncoderModel
 from cortexlab.core.attention import AttentionExtractor, attention_to_roi_scores
+from cortexlab.core.model import FmriEncoder, FmriEncoderModel
 from cortexlab.core.subject import SubjectAdapter
 
 __all__ = [

--- a/src/cortexlab/data/studies/lebel2023bold.py
+++ b/src/cortexlab/data/studies/lebel2023bold.py
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 """Natural language fMRI dataset: 3T fMRI responses to spoken narrative stories.
 
-This dataset provides fMRI data from participants listening to natural spoken 
-narratives (stories) during 3T scanning. The stimuli include various narrative 
-audio stories with detailed word-level and phoneme-level annotations. The dataset 
+This dataset provides fMRI data from participants listening to natural spoken
+narratives (stories) during 3T scanning. The stimuli include various narrative
+audio stories with detailed word-level and phoneme-level annotations. The dataset
 is designed for studying natural language processing in the brain.
 
 Experimental Design:
@@ -19,7 +19,7 @@ Experimental Design:
         * Audio narratives with 10-second blank period before story onset
         * Test story: "wheretheressmoke" (with 10 runs)
         * Training stories: diverse narrative content
-    - Localizer tasks included: AudioMotorLocalizer, AuditoryLocalizer, 
+    - Localizer tasks included: AudioMotorLocalizer, AuditoryLocalizer,
       CategoryLocalizer, MotorLocalizer
 
 Data Format:
@@ -36,7 +36,7 @@ Study Classes:
         - Available spaces: T1w, MNI152NLin6Asym, fsaverage, fsnative
         - 432 timelines (all sessions/runs)
         - Full BIDS structure with multiple space outputs
-        
+
     2. **LebelProcessed2023Bold**: Uses authors' custom HDF5 preprocessing
         - Custom cortical surface registration
         - 200 timelines (aggregated by subject x task)

--- a/src/cortexlab/training/experiment.py
+++ b/src/cortexlab/training/experiment.py
@@ -36,15 +36,15 @@ from neuraltrain.utils import BaseExperiment, WandbLoggerConfig
 from torch import nn
 from torch.utils.data import DataLoader
 
-from cortexlab.data.transforms import *  # register custom events transforms in neuralset
 from cortexlab.core.model import *  # register custom models in neuraltrain
-from cortexlab.data.studies import *  # register studies
+from cortexlab.data.fmri import *  # register TribeSurfaceProjector
 from cortexlab.data.loader import (
     MultiStudyLoader,
     set_study_in_average_subject_mode,
     split_segments_by_time,
 )
-from cortexlab.data.fmri import *  # register TribeSurfaceProjector
+from cortexlab.data.studies import *  # register studies
+from cortexlab.data.transforms import *  # register custom events transforms in neuralset
 
 # Configure logger
 LOGGER = logging.getLogger(__name__)

--- a/src/cortexlab/viz/subcortical.py
+++ b/src/cortexlab/viz/subcortical.py
@@ -114,8 +114,6 @@ def get_mask(label: str, resolution: tp.Literal["1mm", "2mm"] = "1mm"):
             "Cerebellum atlas (Diedrichsen 2009) is not yet supported. "
             "Provide the atlas path manually."
         )
-        img = nib.load(file)
-        mask = img.get_fdata() > 0  # merge all lobules automatically
     elif label == "Brain-Stem":
         # subcortical, return hemisphere-specific mesh (default: right)
         idx = ho_sub.labels.index(label)

--- a/src/cortexlab/viz/utils.py
+++ b/src/cortexlab/viz/utils.py
@@ -376,9 +376,9 @@ def set_title(axes, title, x_offset=0, y_offset=0, **kwargs):
     x = x + x_offset
     y = axes[0].get_position().y1 + y_offset
     fig = axes[0].get_figure()
-    if not "ha" in kwargs:
+    if "ha" not in kwargs:
         kwargs["ha"] = "center"
-    if not "va" in kwargs:
+    if "va" not in kwargs:
         kwargs["va"] = "top"
     fig.text(x, y, title, **kwargs)
 


### PR DESCRIPTION
## Summary

Cleans up 10 of 15 standing ruff errors in `src/`. No behaviour change; 280 tests pass.

## Fixes

| Site | Code | Fix |
|---|---|---|
| `cortexlab/__init__.py:10` | I001 | ruff --fix import sort |
| `cortexlab/training/experiment.py:15` | I001 | ruff --fix import sort |
| `cortexlab/viz/utils.py:379, 381` | E713 | ruff --fix `not in` |
| `cortexlab/data/studies/lebel2023bold.py:8, 9, 10, 22` | W291 | trim trailing whitespace |
| `cortexlab/data/studies/lebel2023bold.py:39` | W293 | trim blank-line whitespace |
| `cortexlab/viz/subcortical.py:117` | F821 | drop dead code past `raise NotImplementedError` |

Plus `.gitignore` learns about `SESSION_STATE.md` so the local working file stops getting auto-staged via `git add -A`.

## Out of scope (deliberately)

The 5 remaining F841 unused-local warnings in `viz/base.py` and `viz/cortical.py` are reasonable good-first-issue scope — tracked in a separate issue rather than rolled in here, so a newcomer can pick them up.

## Test plan

- [x] `python -m ruff check src/` — drops from 15 errors to 5 (the F841 set)
- [x] `python -m pytest tests/ -q` — 280 passed, 3 CUDA-skipped, no regressions