### PR TITLE
docs: fix broken doctest in BrainAlignmentBenchmark (#65)

### DIFF
--- a/src/cortexlab/analysis/brain_alignment.py
+++ b/src/cortexlab/analysis/brain_alignment.py
@@ -110,12 +110,15 @@ _METHODS = {
 class BrainAlignmentBenchmark:
     """Benchmark AI model representations against predicted brain responses.
 
-    Example
-    -------
+    Examples
+    --------
+    >>> import numpy as np
+    >>> brain_predictions = np.random.randn(50, 200)
+    >>> clip_features = np.random.randn(50, 512)
     >>> bench = BrainAlignmentBenchmark(brain_predictions)
     >>> result = bench.score_model(clip_features, method="rsa")
-    >>> print(result.aggregate_score)
-    0.42
+    >>> result is not None
+    True
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

The class-level docstring on \`BrainAlignmentBenchmark\` (\`src/cortexlab/analysis/brain_alignment.py:111\`) referenced \`brain_predictions\` and \`clip_features\` as if they were already in scope, so the example failed as a doctest with NameError.

This applies the same fix PR #52 already used for the analogous \`score_model\` method docstring: self-contained \`np.random.randn(...)\` stub inputs and an \`is not None\` style assertion in place of the hardcoded \`0.42\`.

## Verification

\`\`\`
$ python -c "import doctest, sys; sys.path.insert(0, 'src'); import cortexlab.analysis.brain_alignment as m; r = doctest.testmod(m); assert r.failed == 0; print(f'attempted: {r.attempted}  failed: {r.failed}')"
attempted: 13  failed: 0
\`\`\`

## Test plan

- [ ] CI lint passes
- [ ] CI test passes (277 passed, 6 skipped on master baseline)

Closes #65.