### PR TITLE
Add runnable doctest examples for analysis modules

### DIFF
--- a/src/cortexlab/analysis/cognitive_load.py
+++ b/src/cortexlab/analysis/cognitive_load.py
@@ -130,9 +130,17 @@ class CognitiveLoadScorer:
 
     Example
     -------
+    >>> import numpy as np
+    >>> roi_indices = {
+    ...     "V1": np.array([0, 1]),
+    ...     "A1": np.array([2, 3]),
+    ...     "44": np.array([4, 5]),
+    ... }
+    >>> predictions = np.random.randn(10, 6)
     >>> scorer = CognitiveLoadScorer(roi_indices)
     >>> result = scorer.score_predictions(predictions)
-    >>> print(f"Overall load: {result.overall_load:.2f}")
+    >>> result is not None
+    True
     """
 
     def __init__(
@@ -219,6 +227,20 @@ class CognitiveLoadScorer:
         Returns
         -------
         CognitiveLoadResult
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> roi_indices = {
+        ...     "V1": np.array([0, 1]),
+        ...     "A1": np.array([2, 3]),
+        ...     "44": np.array([4, 5]),
+        ... }
+        >>> predictions = np.random.randn(10, 6)
+        >>> scorer = CognitiveLoadScorer(roi_indices)
+        >>> result = scorer.score_predictions(predictions)
+        >>> result is not None
+        True
         """
         if predictions.ndim == 1:
             predictions = predictions[np.newaxis, :]

--- a/src/cortexlab/analysis/connectivity.py
+++ b/src/cortexlab/analysis/connectivity.py
@@ -30,10 +30,17 @@ class ROIConnectivityAnalyzer:
 
     Example
     -------
+    >>> import numpy as np
+    >>> roi_indices = {
+    ...     "V1": np.array([0, 1]),
+    ...     "A1": np.array([2, 3]),
+    ...     "44": np.array([4, 5]),
+    ... }
+    >>> predictions = np.random.randn(20, 6)
     >>> analyzer = ROIConnectivityAnalyzer(roi_indices)
-    >>> result = analyzer.analyze(predictions, n_clusters=4)
-    >>> print(result.correlation_matrix.shape)
-    (11, 11)
+    >>> result = analyzer.analyze(predictions, n_clusters=2)
+    >>> result is not None
+    True
     """
 
     def __init__(self, roi_indices: dict[str, np.ndarray]):
@@ -184,6 +191,20 @@ class ROIConnectivityAnalyzer:
         Returns
         -------
         ConnectivityResult
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> roi_indices = {
+        ...     "V1": np.array([0, 1]),
+        ...     "A1": np.array([2, 3]),
+        ...     "44": np.array([4, 5]),
+        ... }
+        >>> predictions = np.random.randn(20, 6)
+        >>> analyzer = ROIConnectivityAnalyzer(roi_indices)
+        >>> result = analyzer.analyze(predictions, n_clusters=2)
+        >>> result is not None
+        True
         """
         corr, names = self.compute_correlation_matrix(predictions)
         clusters = self.cluster_networks(corr, names, n_clusters)

--- a/src/cortexlab/analysis/lesion.py
+++ b/src/cortexlab/analysis/lesion.py
@@ -138,6 +138,31 @@ def run_modality_lesion(
     Returns
     -------
     LesionResult
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> features_train = {
+    ...     "text": rng.standard_normal((50, 4)).astype(np.float32),
+    ...     "audio": rng.standard_normal((50, 4)).astype(np.float32),
+    ...     "video": rng.standard_normal((50, 4)).astype(np.float32),
+    ... }
+    >>> features_test = {
+    ...     "text": rng.standard_normal((10, 4)).astype(np.float32),
+    ...     "audio": rng.standard_normal((10, 4)).astype(np.float32),
+    ...     "video": rng.standard_normal((10, 4)).astype(np.float32),
+    ... }
+    >>> y_train = rng.standard_normal((50, 6)).astype(np.float32)
+    >>> y_test = rng.standard_normal((10, 6)).astype(np.float32)
+    >>> result = run_modality_lesion(
+    ...     features_train,
+    ...     features_test,
+    ...     y_train,
+    ...     y_test,
+    ... )
+    >>> result is not None
+    True
     """
     if mask_strategy not in ("zero", "learned"):
         raise ValueError(f"mask_strategy must be zero|learned, got {mask_strategy!r}")

--- a/src/cortexlab/analysis/stats.py
+++ b/src/cortexlab/analysis/stats.py
@@ -52,6 +52,14 @@ def bh_fdr(
         Q-values, same shape and dtype family (``float64``) as the
         input. NaN entries in the input remain NaN in the output.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> pvals = np.array([0.001, 0.5, 0.04, 0.99])
+    >>> result = bh_fdr(pvals)
+    >>> result is not None
+    True
+
     Notes
     -----
     The classic Benjamini-Hochberg procedure (1995):

--- a/src/cortexlab/analysis/temporal_dynamics.py
+++ b/src/cortexlab/analysis/temporal_dynamics.py
@@ -30,9 +30,14 @@ class TemporalDynamicsAnalyzer:
 
     Example
     -------
+    >>> import numpy as np
+    >>> roi_indices = {"V1": np.array([0, 1, 2])}
+    >>> predictions = np.random.randn(10, 3)
+    >>> model_features = np.random.randn(10, 5)
     >>> analyzer = TemporalDynamicsAnalyzer(roi_indices, tr_seconds=1.0)
     >>> result = analyzer.analyze(predictions, model_features)
-    >>> print(f"V1 peak latency: {result.peak_latencies['V1']:.1f}s")
+    >>> result is not None
+    True
     """
 
     def __init__(
@@ -187,6 +192,17 @@ class TemporalDynamicsAnalyzer:
         Returns
         -------
         TemporalDynamicsResult
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> roi_indices = {"V1": np.array([0, 1, 2])}
+        >>> predictions = np.random.randn(10, 3)
+        >>> model_features = np.random.randn(10, 5)
+        >>> analyzer = TemporalDynamicsAnalyzer(roi_indices, tr_seconds=1.0)
+        >>> result = analyzer.analyze(predictions, model_features)
+        >>> result is not None
+        True
         """
         result = TemporalDynamicsResult()
 


### PR DESCRIPTION
## Summary
Add runnable NumPy-style doctest examples to public methods in `cortexlab.analysis.* ` following the pattern introduced in PR #52.

The new examples use synthetic inputs and `is not None` style assertions so they remain stable across NumPy versions and execution environments.

In addition, I updated a few existing examples that referenced undefined variables so that all doctest examples are self-contained and executable.

## Changes

- Added runnable doctest example for cortexlab.analysis.stats.bh_fdr
- Added runnable doctest example for cortexlab.analysis.cognitive_load.CognitiveLoadScorer.score_predictions
- Added runnable doctest example for cortexlab.analysis.temporal_dynamics.TemporalDynamicsAnalyzer.analyze
- Added runnable doctest example for cortexlab.analysis.connectivity.ROIConnectivityAnalyzer.analyze
- Added runnable doctest example for cortexlab.analysis.lesion.run_modality_lesion

## Self-contained example fixes

While validating doctests, I found existing class-level examples that referenced undefined variables and failed when executed via doctest.testmod().

Updated the following examples to include stub inputs:

- `cortexlab.analysis.cognitive_load.CognitiveLoadScorer` : Added stub roi_indices and predictions
- `cortexlab.analysis.temporal_dynamics.TemporalDynamicsAnalyzer` : Added stub roi_indices, predictions, and model_features
- `cortexlab.analysis.connectivity.ROIConnectivityAnalyzer.analyze` : Added stub roi_indices and predictions

These changes make the examples self-contained and satisfy the issue requirement that examples should not depend on undefined names.

## Testing
- [x] All existing tests pass (`pytest tests/ -v`)
- [x] Lint passes (`ruff check src/ tests/`)
- [x] Doctests pass for all touched modules 
- [x] Pre-commit checks pass
- [x] Tested manually with doctest execution

## Related Issues
Closes #66